### PR TITLE
Production deployment: broker integration, backtesting, scheduling, security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,17 @@ BENCHMARK_SYMBOL=SPY
 # Allow fractional shares (required for small portfolios; Alpaca supports this).
 FRACTIONAL_SHARES=true
 
-# ── Data ─────────────────────────────────────────────────────────────────────
-# Path to the price database pickle produced by database_handler.update_database().
+# ── Data source ───────────────────────────────────────────────────────────────
+# "alpaca" — fetch from Alpaca Market Data API (recommended for daily trading).
+# "local"  — read from local pickle files (legacy; useful for offline backtesting).
+DATA_SOURCE=alpaca
+
+# Used only when DATA_SOURCE=alpaca.
+# Parquet cache directory (one file per ticker; updated incrementally each day).
+DATA_CACHE_DIR=./data/cache/alpaca
+
+# Used only when DATA_SOURCE=local.
 DATA_FILE=./data/close.pkl
-# Path to the metadata pickle (sector, name, market cap per ticker).
 METADATA_FILE=./data/metadata.pkl
 
 # ── Scheduling / state ───────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# PortfolioManager — daily job configuration
+# Copy this file to .env and fill in your values.
+# .env is listed in .gitignore and must never be committed.
+
+# ── Broker ───────────────────────────────────────────────────────────────────
+# Alpaca API credentials (https://app.alpaca.markets → API Keys)
+# Leave blank to run with a local PaperBroker (no real trades, no account needed).
+ALPACA_API_KEY=
+ALPACA_SECRET_KEY=
+# Set to "false" for live trading (use live keys, not paper keys).
+ALPACA_PAPER=true
+
+# ── Account ───────────────────────────────────────────────────────────────────
+# Name of the account folder under ACCOUNT_PATH.
+ACCOUNT_NAME=my_portfolio
+# Directory where account snapshots (.acc files) are stored.
+ACCOUNT_PATH=./accounts
+
+# ── Strategy ─────────────────────────────────────────────────────────────────
+# Number of calendar days of return history fed to the CVaR optimizer.
+LOOKBACK_DAYS=252
+# Ticker used as the passive benchmark in performance reports.
+BENCHMARK_SYMBOL=SPY
+# Allow fractional shares (required for small portfolios; Alpaca supports this).
+FRACTIONAL_SHARES=true
+
+# ── Data ─────────────────────────────────────────────────────────────────────
+# Path to the price database pickle produced by database_handler.update_database().
+DATA_FILE=./data/close.pkl
+# Path to the metadata pickle (sector, name, market cap per ticker).
+METADATA_FILE=./data/metadata.pkl
+
+# ── Scheduling / state ───────────────────────────────────────────────────────
+# Directory for idempotency lock and success markers.
+RUN_STATE_DIR=./run_state
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+LOG_DIR=./logs
+# Python log level: DEBUG | INFO | WARNING | ERROR
+LOG_LEVEL=INFO

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,25 +11,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Python 3
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Install Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest-cov
-      - name: Create environment file
-        run: |
-          touch .env
-          echo "${PYTHONPATH}"
-          echo PYTHONPATH="${PYTHONPATH};home/runner/work/PortfolioManager/PortfolioManager/source" >> .env
       - name: Run tests with pytest
+        env:
+          PYTHONPATH: ${{ github.workspace }}/source
         run: |
-          pytest --cov=source --cov-report=xml tests/ > portfolio_cov.xml
+          pytest --cov=source --cov-report=xml tests/ -q \
+            --ignore=tests/test_database_handler.py
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
-          files: ./portfolio_cov.xml,./coverage.xml
+          files: ./coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@
 
 # Unused files
 *broken/
+
+# Runtime state (idempotency markers, lock files)
+run_state/
+
+# Log output
+logs/
+
+# Account data directories
+accounts/

--- a/DEPLOYMENT_PLAN.md
+++ b/DEPLOYMENT_PLAN.md
@@ -1,0 +1,276 @@
+# PortfolioManager: Production Deployment Plan
+
+## Context
+
+The PortfolioManager is a CVaR-based portfolio optimizer that generates buy/sell orders but has no automated execution, no broker integration, no scheduling, and no monitoring. The goal is to deploy it to run daily and place real trades automatically. The plan covers backtesting validation, broker selection, deployment architecture, scheduling, security, and monitoring.
+
+---
+
+## 1. Backtesting
+
+### Current Gaps
+- `benchmark()` / `build_account_history()` are performance *measurement*, not true backtesting — they evaluate already-executed portfolios, not historical decisions.
+- `DataManager.get_returns()` caches `self._returns` on first call regardless of date args — silently reuses stale data in any walk-forward loop.
+- `update_database()` drops columns with all-NaN (delisted stocks removed) = survivorship bias.
+- No transaction cost modeling.
+
+### Walk-Forward Design
+```
+for rebalance_date in backtest_calendar:
+    train_window = [rebalance_date - lookback, rebalance_date]
+    1. Fetch prices strictly as-of rebalance_date
+    2. Run cvar_model_ortools on those returns
+    3. Apply transaction cost haircut to orders
+    4. Update simulated portfolio
+    5. Record portfolio value
+```
+Key fix: pass `end_date=rebalance_date` strictly; fix `_returns` caching bug first.
+
+### Transaction Costs to Model
+| Type | Approach |
+|---|---|
+| Commission | $0 Alpaca, $0.005/share IBKR |
+| Bid-ask spread | `fill_price = mid * (1 ± spread/2)`; ~5bps for large-cap |
+| Slippage | 0.1–0.2% on order size (negligible for <$500K) |
+
+### Risk Metrics to Add
+- Sharpe, Sortino, Calmar (annualized return / max drawdown)
+- Max drawdown, rolling beta vs SPY
+- Turnover (fraction of portfolio replaced per rebalance)
+- Win rate vs benchmark
+
+### Recommended Libraries
+- **VectorBT** — walk-forward simulation engine, numpy-native, fast
+- **QuantStats** — HTML tearsheet generation from equity curve
+- `pandas-market-calendars` — NYSE holiday schedule for both backtester and scheduler
+
+### Data Quality Fixes
+- Survivorship bias: maintain `constituents.pkl` mapping `(date, index) → [tickers]`; use period-accurate universe per rebalance date
+- Split/dividend consistency: verify `close.pkl` uses adjusted close throughout
+- Missing data: forward-fill up to 5 days, then drop (current `dropna(axis=1)` is too aggressive)
+- Holiday NaN rows: replace weekday-only date filtering with NYSE calendar
+
+---
+
+## 2. Broker Options
+
+### Alpaca ✅ Recommended
+- Commission-free; paper trading environment with separate keys
+- Fractional shares on market orders (aligns with `fractional=True` flag)
+- Good REST API; `alpaca-py` is the current maintained SDK
+- **Action**: Remove deprecated `alpaca_trade_api==1.2.3`; add `alpaca-py>=0.18.0`
+- IP allowlisting supported — use it
+
+### Interactive Brokers
+- Broader instruments (options, futures, international)
+- Requires TWS or IB Gateway running as a local process — complicates cloud deployment
+- Python: `ib_insync`
+- Not recommended unless you need instruments beyond US equities/ETFs
+
+### Schwab (post-TD Ameritrade)
+- No paper trading environment; no fractional shares — hard blockers for this project
+
+### Tradier
+- No fractional shares; no official Python SDK — inferior to Alpaca for this use case
+
+---
+
+## 3. Deployment Architecture
+
+### Option A: Cloud VPS — ✅ Recommended for solo developer
+- DigitalOcean / Hetzner / Linode: ~$6–12/month
+- Always-on, persistent disk, easy to SSH/debug
+- systemd timer for scheduling, environment variables for secrets
+- Add nightly backup to cloud storage (~$1–2/month)
+
+### Option B: GCP Cloud Run Jobs + Cloud Scheduler
+- Containerized Python task; ~$0.006/run; Cloud Scheduler: $0.10/month
+- Good fit if already using GCP; cleaner for ops at scale
+- Slightly higher setup complexity (Docker, Artifact Registry, Service Account)
+
+### Option C: AWS EC2 t3.micro / Fargate
+- EC2: ~$8–12/month on-demand; similar to VPS with better native AWS integration
+- Fargate: elegant for scheduled workloads; 30–90s cold start acceptable for daily runs
+- OR-Tools (~100MB compiled binary) likely exceeds Lambda's 250MB limit → avoid Lambda
+
+### Option D: GitHub Actions scheduled workflows
+- Free tier covers ~220 min/month (fits within limit)
+- **Not recommended for real money**: timing unreliability (up to 30min queue delay), no persistent state between runs
+- Fine for backtesting CI jobs and paper trading sanity checks
+
+---
+
+## 4. Scheduling Strategy
+
+### Trigger Time
+- **10:00 ET** (30 min after open): avoids opening volatility, still within trading window
+- Cron UTC: `0 15 * * 1-5` (EDT) / `0 14 * * 1-5` (EST)
+- **Better**: Start script with a `pandas_market_calendars` NYSE check; exit cleanly on holidays/early close
+
+### Idempotency (Critical — currently absent)
+1. Write a run-lock record at job start; check it on re-entry; write success marker at end
+2. Before submitting orders, query broker for existing positions; skip orders already filled
+3. Pass `client_order_id = f"{account}_{date}_{ticker}_{side}"` to Alpaca — duplicate rejected with 422
+
+### Retry Logic
+- API-level: already in `update_stock_prices()` (3 retries); extend to order submission
+- Job-level (systemd): `Restart=on-failure`, `RestartSec=900`, `StartLimitBurst=3`
+
+---
+
+## 5. Security
+
+### Secrets Management
+- **Development**: `.env` + `python-dotenv`; must be in `.gitignore`
+- **VPS production**: systemd `EnvironmentFile=/etc/portfolio-manager/secrets.env` with `chmod 600`, owned by service user
+- **Cloud**: AWS Secrets Manager or GCP Secret Manager
+
+### API Key Practices
+- Separate paper vs. live keys; never use live keys in dev/test
+- Alpaca: use minimal permissions (`orders:write`, `positions:read`, `account:read`)
+- Enable IP allowlisting on Alpaca dashboard — only the VPS IP can trade
+- Rotate keys monthly; revoke old key after new one confirmed working
+
+### State File Protection
+- Add `*.pkl`, `*.acc`, `data/`, `accounts/` to `.gitignore` immediately
+- Encrypt data directory (LUKS on VPS, or SSE on S3/GCS)
+- Daily backup to a separate cloud storage bucket
+- Use atomic writes: write temp file → rename (avoids corrupt state on crash)
+
+### Audit Trail
+- Log every order submission and every fill confirmation to an append-only file
+- Include: ticker, side, qty, intended price, fill price, fill time, broker order ID
+- Retain ≥7 years (IRS/FINRA personal trading record requirements)
+
+---
+
+## 6. Monitoring and Alerting
+
+### Logging
+Replace all `print()` statements with structured JSON logging:
+- **INFO**: job start/end, each order, each fill, portfolio snapshot, CVaR stats
+- **WARNING**: stale prices, optimizer gap > threshold, partial fills
+- **ERROR**: API failures, optimizer infeasible
+- **CRITICAL**: broker rejection, state inconsistency
+
+Start with rotating file logs on VPS. Add Loki + Grafana (self-hosted, ~200MB RAM) for dashboards when Phase 2 is stable.
+
+### Alerting
+1. **Email** (Phase 2): `smtplib` or SendGrid free tier; send on ERROR/CRITICAL
+2. **Slack webhook** (Phase 2): formatted message on failure
+3. **SMS via Twilio** (Phase 3): for CRITICAL events only (~$0.008/SMS)
+
+### Portfolio Drift Monitoring
+- Daily check even on non-rebalance days
+- Alert if any position drifts >5% absolute from target weights
+
+### Daily Report (automated email after execution)
+- Portfolio value: today vs. yesterday vs. 30 days ago
+- SPY benchmark comparison
+- Orders placed with fill prices
+- Running Sharpe, max drawdown, Calmar
+- CVaR stats for new portfolio
+- `benchmark2()` in `account_manager.py` already generates most of this; remove `plt.show()`, save figures to file
+
+---
+
+## 7. Phased Implementation Plan
+
+### Phase 1: Backtesting + Paper Trading (4–8 weeks)
+
+**Week 1–2: Fix Data Quality**
+- Fix `DataManager._returns` caching bug (stale data in walk-forward loops)
+- Add `pandas-market-calendars` for NYSE holiday handling in `update_database()`
+- Add `*.pkl`, `*.acc` to `.gitignore`
+- Fix pandas 2.0 compat: replace `DataFrame.append()` with `pd.concat()` in `resources.py`
+
+**Week 3–4: Walk-Forward Backtester**
+- Build `backtest.py` with `walkforward_backtest()` function
+- Integrate transaction cost model
+- Compute Sharpe, max drawdown, Calmar, turnover from equity curve
+- Run on 5+ years historical data; generate QuantStats tearsheet
+
+**Week 5–6: Alpaca Paper Trading**
+- Upgrade to `alpaca-py`; create `broker/alpaca_broker.py` adapter
+- Implement `submit_order()`, `get_fill()`, `get_positions()`, `cancel_order()`
+- Run first paper trade cycle manually
+
+**Week 7–8: Scheduling + Basic Alerting**
+- Create `run_daily.py` as main entry point
+- Add NYSE holiday check, idempotency guard, failure email alert
+- Set up cron/systemd on VPS
+
+**Go/No-Go Gate**: 4 weeks paper trading; P&L within 2 std dev of backtest distribution → proceed to Phase 2.
+
+### Phase 2: Real Money with Small Capital (2–4 weeks)
+- Obtain live Alpaca keys; configure IP allowlisting; set up systemd EnvironmentFile
+- Add fill-confirmation loop: submit → poll → record actual fill price in Account
+- Move state files to encrypted directory with daily cloud backup
+- Atomic account saves after every order batch
+- Automate daily email report; replace remaining `print()` with logging
+
+### Phase 3: Hardening (ongoing)
+- JSON structured logging with log rotation
+- Slack alerting integrated into logging framework
+- Portfolio drift monitoring
+- systemd job-level retry (`Restart=on-failure`)
+- Prometheus metrics + Grafana dashboard
+- Monthly key rotation calendar reminder
+- Evaluate migration to GCP Cloud Run Jobs for better scheduling reliability
+
+---
+
+## 8. Code Changes Required
+
+### `requirements.txt`
+- Remove `alpaca_trade_api==1.2.3` (deprecated)
+- Add `alpaca-py>=0.18.0`
+- Add `pandas-market-calendars>=4.3.0`
+- Add `python-dotenv>=1.0.0`
+- Add `quantstats>=0.0.62`
+- Upgrade `yfinance` to `>=0.2.40` (0.1.63 is years old, many endpoints changed)
+- Upgrade `pandas` to `>=2.0` (1.1.2 from 2020; `DataFrame.append()` removed in 2.0)
+- Upgrade `ortools` to `>=9.0` (8.0 from 2020)
+- Remove `gurobipy==9.1.2` (no Gurobi license; not referenced in any source file)
+- Pin Python `>=3.10` (3.8 EOL October 2024)
+
+### `source/resources.py`
+- Replace all `DataFrame.append()` calls with `pd.concat()` — **blocking bug on modern pandas**
+- Add `TradeRecord` dataclass: fill price, fill time, broker order ID
+- Modify `Account.update_account()` to accept `TradeRecord` (actual fill prices) not `Order` (optimizer prices)
+- Add `Account.has_traded_today(date)` for idempotency
+- Add `save_account_atomic()`: write to temp file → rename
+
+### `source/database_handler.py`
+- Fix `get_returns()` caching: key cache on `(start_date, end_date, tuple(stocks))`
+- Add `get_returns_as_of(date, lookback_days)` for walk-forward backtesting
+- Replace weekday date filtering with `pandas_market_calendars` NYSE schedule
+- Replace `print()` with structured logging
+
+### `source/account_manager.py`
+- Remove all `plt.show()` calls (block headless execution)
+- Add `save_figure=None` param to benchmark functions
+- Extract `compute_risk_metrics(equity_curve, benchmark_curve, risk_free_rate)` as standalone function
+- Replace `print()` with logging
+
+### `source/opt_tools.py`
+- Add solver timeout: `solver.set_time_limit(30_000)` (30s; currently unlimited — MIP can run forever)
+- Add solver status check: raise exception on `INFEASIBLE`/`ABNORMAL` instead of returning garbage values
+- Add solver status to returned `stats` dict
+- Replace `print()` with DEBUG-level logging
+
+### New files to create
+- `source/broker/alpaca_broker.py` — Alpaca broker adapter + PaperBroker mock
+- `source/backtest.py` — walk-forward backtesting loop + risk metrics
+- `run_daily.py` — main scheduled entry point (market check → data update → optimize → submit → fill → save → report)
+
+---
+
+## Verification
+
+1. **Backtesting**: Run `walkforward_backtest()` on 2019–2024 data; confirm Sharpe > 0 and drawdown within acceptable bounds; compare equity curve to SPY benchmark
+2. **Paper trading**: Let `run_daily.py` execute for 4+ weeks against Alpaca paper environment; verify orders appear in Alpaca dashboard; verify `Account` state matches Alpaca positions
+3. **Idempotency**: Manually run `run_daily.py` twice on the same day; confirm second run exits cleanly without submitting duplicate orders
+4. **Failure alerting**: Kill the process mid-run; confirm email/Slack alert fires within 5 minutes
+5. **State persistence**: Simulate a crash mid-write; confirm `save_account_atomic()` leaves the account file uncorrupted
+6. **Live trading**: Place first real trade with $1,000–5,000; verify fill price recorded in Account matches Alpaca fill confirmation

--- a/deploy/portfolio-manager.service
+++ b/deploy/portfolio-manager.service
@@ -1,0 +1,53 @@
+# systemd service unit for the PortfolioManager daily job.
+#
+# Install:
+#   sudo cp portfolio-manager.service /etc/systemd/system/
+#   sudo cp portfolio-manager.timer   /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now portfolio-manager.timer
+#
+# Check logs:
+#   journalctl -u portfolio-manager.service -f
+#   tail -f /var/log/portfolio-manager/portfolio.log
+#   tail -f /var/log/portfolio-manager/audit.log
+
+[Unit]
+Description=PortfolioManager daily rebalancing job
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+# Run as a dedicated non-root user for isolation.
+# Create with: sudo useradd -r -s /sbin/nologin portfolio
+User=portfolio
+Group=portfolio
+
+WorkingDirectory=/opt/portfolio-manager
+
+# Secrets are stored in this file with chmod 600, owned by portfolio.
+# Never put secrets in this unit file (it is world-readable).
+EnvironmentFile=/etc/portfolio-manager/secrets.env
+
+ExecStart=/opt/portfolio-manager/venv/bin/python run_daily.py
+
+# Restart on failure, up to 3 times, waiting 15 min between attempts.
+# This handles transient network issues; persistent failures alert via logs.
+Restart=on-failure
+RestartSec=900
+StartLimitBurst=3
+StartLimitIntervalSec=3600
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=/opt/portfolio-manager/accounts /opt/portfolio-manager/run_state /opt/portfolio-manager/logs /var/log/portfolio-manager
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=portfolio-manager
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/portfolio-manager.timer
+++ b/deploy/portfolio-manager.timer
@@ -1,0 +1,23 @@
+# systemd timer — triggers the daily job at 10:00 ET on weekdays.
+#
+# OnCalendar uses UTC.  NYSE opens at 09:30 ET; 10:00 ET = 15:00 UTC (EDT)
+# or 14:00 UTC (EST, Nov–Mar).  Using 15:00 UTC is safe year-round because
+# the job itself checks pandas_market_calendars and exits on holidays/weekends.
+#
+# Adjust the hour if your server is always on EST (use 15 Nov–Mar, 14 Apr–Oct).
+
+[Unit]
+Description=PortfolioManager daily rebalancing timer
+Requires=portfolio-manager.service
+
+[Timer]
+# Fire at 15:00 UTC Mon–Fri (= 10:00 ET during EDT / 11:00 ET during EST).
+# The run_daily.py NYSE check handles the EST/EDT difference correctly.
+OnCalendar=Mon..Fri 15:00:00 UTC
+# If the system was off at trigger time, run as soon as it comes back up
+# (within 60 seconds of boot, capped at the next scheduled trigger time).
+Persistent=true
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pandas==1.1.2
 ortools==8.0.8283
 pytest==6.2.4
 yfinance==0.1.63
-alpaca_trade_api==1.2.3
+alpaca-py>=0.18.0
 beautifulsoup4==4.9.3
-gurobipy==9.1.2
+python-dotenv>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.24.0
+requests>=2.31.0
 numpy>=1.26.4
 matplotlib>=3.9.0
 pandas>=2.2.0
@@ -7,6 +7,6 @@ pytest>=7.4.0
 yfinance>=0.2.40
 alpaca-py>=0.18.0
 pyarrow>=14.0.0
-beautifulsoup4==4.9.3
+beautifulsoup4>=4.11.1
 python-dotenv>=1.0.0
 pandas-market-calendars>=4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ yfinance==0.1.63
 alpaca-py>=0.18.0
 beautifulsoup4==4.9.3
 python-dotenv>=1.0.0
+pandas-market-calendars>=4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
-pandas_datareader==0.9.0
 requests==2.24.0
-numpy==1.19.2
-matplotlib==3.3.1
-pandas==1.1.2
-ortools==8.0.8283
-pytest==6.2.4
-yfinance==0.1.63
+numpy>=1.26.4
+matplotlib>=3.9.0
+pandas>=2.2.0
+ortools>=9.5.0
+pytest>=7.4.0
+yfinance>=0.2.40
 alpaca-py>=0.18.0
 pyarrow>=14.0.0
 beautifulsoup4==4.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ ortools==8.0.8283
 pytest==6.2.4
 yfinance==0.1.63
 alpaca-py>=0.18.0
+pyarrow>=14.0.0
 beautifulsoup4==4.9.3
 python-dotenv>=1.0.0
 pandas-market-calendars>=4.3.0

--- a/run_daily.py
+++ b/run_daily.py
@@ -1,0 +1,314 @@
+"""Daily rebalancing entry point.
+
+Run this script once a day (e.g. via cron or systemd timer at 10:00 ET).
+It will:
+  1. Exit cleanly if today is not a NYSE trading day.
+  2. Exit cleanly if the job already succeeded today (idempotency).
+  3. Load the account from disk.
+  4. Run the CVaR optimizer to produce rebalancing orders.
+  5. Submit orders to the configured broker (paper or live Alpaca).
+  6. Record fills and save the account atomically.
+  7. Write an audit log entry for every order and fill.
+
+Configuration is read from environment variables (see .env.example).
+For local development, copy .env.example → .env and fill in values;
+the script loads it automatically via python-dotenv.
+"""
+
+import datetime as dt
+import logging
+import logging.handlers
+import os
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Bootstrap: add source/ to path before any local imports
+# ---------------------------------------------------------------------------
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE / "source"))
+
+# Load .env if present (python-dotenv; silently skipped if not installed)
+try:
+    from dotenv import load_dotenv
+    load_dotenv(_HERE / ".env")
+except ImportError:
+    pass
+
+# ---------------------------------------------------------------------------
+# Logging setup  (must happen before other imports so handlers are in place)
+# ---------------------------------------------------------------------------
+
+def _setup_logging(log_dir: Path, level: str = "INFO") -> logging.Logger:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    fmt = logging.Formatter(
+        "%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    # Rotating daily log (keep 90 days)
+    fh = logging.handlers.TimedRotatingFileHandler(
+        log_dir / "portfolio.log",
+        when="midnight",
+        backupCount=90,
+        utc=True,
+    )
+    fh.setFormatter(fmt)
+    root.addHandler(fh)
+
+    # Console
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setFormatter(fmt)
+    root.addHandler(ch)
+
+    # Append-only audit log (never rotated — kept for 7+ years)
+    audit_fh = logging.FileHandler(log_dir / "audit.log", mode="a")
+    audit_fh.setFormatter(fmt)
+    audit_logger = logging.getLogger("audit")
+    audit_logger.addHandler(audit_fh)
+    audit_logger.propagate = False  # audit entries only go to audit.log
+
+    return logging.getLogger("run_daily")
+
+
+# ---------------------------------------------------------------------------
+# Config from environment
+# ---------------------------------------------------------------------------
+
+def _env(key: str, default: str = "") -> str:
+    return os.environ.get(key, default).strip()
+
+
+def _env_bool(key: str, default: bool = False) -> bool:
+    v = _env(key, str(default)).lower()
+    return v in ("1", "true", "yes")
+
+
+def _env_int(key: str, default: int = 0) -> int:
+    try:
+        return int(_env(key, str(default)))
+    except ValueError:
+        return default
+
+
+def _env_float(key: str, default: float = 0.0) -> float:
+    try:
+        return float(_env(key, str(default)))
+    except ValueError:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Order submission with retry
+# ---------------------------------------------------------------------------
+
+def _submit_with_retry(broker, order, log, max_retries: int = 3):
+    """Submit a single order, retrying up to *max_retries* times on failure."""
+    for attempt in range(max_retries):
+        try:
+            fill = broker.submit_and_await_fill(order, timeout_seconds=60)
+            return fill
+        except Exception as exc:
+            if attempt == max_retries - 1:
+                raise
+            wait = 5 * (2 ** attempt)  # 5s, 10s, 20s
+            log.warning(
+                "Order %s %s x%s failed (attempt %d/%d): %s — retrying in %ds",
+                order.operation_type, order.ticker, order.qty,
+                attempt + 1, max_retries, exc, wait,
+            )
+            time.sleep(wait)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    log_dir = Path(_env("LOG_DIR", "logs"))
+    log = _setup_logging(log_dir, _env("LOG_LEVEL", "INFO"))
+    audit = logging.getLogger("audit")
+
+    today = dt.date.today()
+    log.info("=== Daily job starting — %s ===", today.isoformat())
+
+    # ── 1. NYSE trading-day check ──────────────────────────────────────────
+    from market_hours import is_trading_day, IdempotencyGuard
+    if not is_trading_day(today):
+        log.info("Today (%s) is not a NYSE trading day. Exiting.", today.isoformat())
+        return 0
+
+    # ── 2. Idempotency guard ───────────────────────────────────────────────
+    run_dir = Path(_env("RUN_STATE_DIR", "run_state"))
+    guard = IdempotencyGuard(run_dir)
+
+    if guard.already_ran(today):
+        log.info("Job already completed successfully today (%s). Exiting.", today.isoformat())
+        return 0
+
+    if not guard.acquire_lock():
+        log.error("Could not acquire run lock — another process may be running.")
+        return 1
+
+    try:
+        return _run(log, audit, today)
+    except Exception:
+        log.exception("Unhandled exception in daily job.")
+        return 2
+    finally:
+        guard.release_lock()
+        log.info("=== Daily job finished — %s ===", today.isoformat())
+
+
+def _run(log, audit, today: dt.date) -> int:
+    from database_handler import DataManager
+    from resources import (
+        load_account, save_account_atomic, set_account_path,
+        Portfolio, generate_orders, OPERATION_BUY, OPERATION_SELL,
+    )
+    from account_manager import rebalance_porfolio
+    from market_hours import IdempotencyGuard
+
+    # ── Config ─────────────────────────────────────────────────────────────
+    account_name   = _env("ACCOUNT_NAME", "my_portfolio")
+    account_dir    = Path(_env("ACCOUNT_PATH", "accounts"))
+    lookback_days  = _env_int("LOOKBACK_DAYS", 252)
+    benchmark      = _env("BENCHMARK_SYMBOL", "SPY")
+    fractional     = _env_bool("FRACTIONAL_SHARES", True)
+    data_file      = _env("DATA_FILE", "close.pkl")
+    meta_file      = _env("METADATA_FILE", "metadata.pkl")
+    paper_mode     = _env_bool("ALPACA_PAPER", True)
+    api_key        = _env("ALPACA_API_KEY")
+    secret_key     = _env("ALPACA_SECRET_KEY")
+    run_dir        = Path(_env("RUN_STATE_DIR", "run_state"))
+
+    set_account_path(account_dir)
+
+    # ── 3. Load account ────────────────────────────────────────────────────
+    account = load_account(account_name)
+    if account is None:
+        log.error(
+            "Account '%s' not found under '%s'. "
+            "Create it first with resources.create_new_account().",
+            account_name, account_dir,
+        )
+        return 1
+    log.info(
+        "Loaded account '%s': cash=%.2f, positions=%s",
+        account_name, account.cash_onhand, list(account.portfolio.assets),
+    )
+
+    # ── 4. Data manager ────────────────────────────────────────────────────
+    try:
+        data_manager = DataManager(
+            db_file=data_file,
+            metadata_file=meta_file,
+        )
+    except Exception as exc:
+        log.error("Failed to load data manager: %s", exc)
+        return 1
+
+    # ── 5. Generate orders via CVaR optimizer ──────────────────────────────
+    end_date   = dt.datetime.combine(today, dt.time(16, 0))  # market close
+    start_date = end_date - dt.timedelta(days=lookback_days)
+
+    try:
+        orders = rebalance_porfolio(
+            portfolio=account.portfolio,
+            additional_cash=account.cash_onhand,
+            start_date=start_date,
+            end_date=end_date,
+            data_manager=data_manager,
+            print_portfolio=False,
+            fractional_stocks=fractional,
+        )
+    except Exception as exc:
+        log.error("Optimizer failed: %s", exc)
+        return 1
+
+    if not orders:
+        log.info("Optimizer produced no orders — portfolio already optimal.")
+        _mark_and_save(account, run_dir, today, log)
+        return 0
+
+    log.info("Optimizer produced %d orders.", len(orders))
+    for o in orders:
+        log.info("  ORDER  %s %s x%.4f @ %.4f", o.operation_type, o.ticker, o.qty, o.price)
+        audit.info("ORDER  account=%s date=%s side=%s ticker=%s qty=%.4f price=%.4f",
+                   account.holder, today.isoformat(), o.operation_type,
+                   o.ticker, o.qty, o.price)
+
+    # ── 6. Broker ──────────────────────────────────────────────────────────
+    broker = _build_broker(api_key, secret_key, paper_mode, account.portfolio, log)
+
+    # ── 7. Submit orders + collect fills ──────────────────────────────────
+    fills = []
+    for order in orders:
+        try:
+            fill = _submit_with_retry(broker, order, log)
+            if fill is None:
+                log.warning("No fill received for %s %s — skipping.", order.operation_type, order.ticker)
+                continue
+            fills.append(fill)
+            log.info(
+                "  FILL   %s %s x%.4f @ %.4f (broker_id=%s)",
+                fill.operation_type, fill.ticker, fill.qty,
+                fill.fill_price, fill.broker_order_id,
+            )
+            audit.info(
+                "FILL   account=%s date=%s side=%s ticker=%s qty=%.4f "
+                "fill_price=%.4f broker_id=%s",
+                account.holder, today.isoformat(), fill.operation_type,
+                fill.ticker, fill.qty, fill.fill_price, fill.broker_order_id,
+            )
+        except Exception as exc:
+            log.error("Order %s %s failed after retries: %s", order.operation_type, order.ticker, exc)
+            audit.error("ORDER_FAILED account=%s date=%s side=%s ticker=%s error=%s",
+                        account.holder, today.isoformat(), order.operation_type, order.ticker, exc)
+
+    # ── 8. Update account + atomic save ───────────────────────────────────
+    if fills:
+        account.update_account_from_fills(
+            dt.datetime.combine(today, dt.time(10, 0)), fills
+        )
+        log.info(
+            "Account updated: cash=%.2f, positions=%s",
+            account.cash_onhand, list(account.portfolio.assets),
+        )
+
+    _mark_and_save(account, run_dir, today, log)
+    return 0
+
+
+def _build_broker(api_key, secret_key, paper_mode, current_portfolio, log):
+    """Return an AlpacaBroker if credentials are configured, else PaperBroker."""
+    if api_key and secret_key:
+        try:
+            from broker.alpaca import AlpacaBroker
+            broker = AlpacaBroker(api_key, secret_key, paper=paper_mode)
+            mode = "paper" if paper_mode else "LIVE"
+            log.info("Using AlpacaBroker (%s).", mode)
+            return broker
+        except Exception as exc:
+            log.error("Failed to connect to Alpaca (%s). Falling back to PaperBroker.", exc)
+
+    from broker.paper import CostAwarePaperBroker
+    log.warning("No Alpaca credentials found — using local CostAwarePaperBroker (no real trades).")
+    return CostAwarePaperBroker(cost_bps=5.0, initial_portfolio=current_portfolio)
+
+
+def _mark_and_save(account, run_dir, today, log):
+    from resources import save_account_atomic
+    from market_hours import IdempotencyGuard
+    save_account_atomic(account)
+    log.info("Account saved atomically.")
+    IdempotencyGuard(run_dir).mark_success(today)
+    log.info("Success marker written for %s.", today.isoformat())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/run_daily.py
+++ b/run_daily.py
@@ -165,7 +165,6 @@ def main() -> int:
 
 
 def _run(log, audit, today: dt.date) -> int:
-    from database_handler import DataManager
     from resources import (
         load_account, save_account_atomic, set_account_path,
         Portfolio, generate_orders, OPERATION_BUY, OPERATION_SELL,
@@ -179,11 +178,13 @@ def _run(log, audit, today: dt.date) -> int:
     lookback_days  = _env_int("LOOKBACK_DAYS", 252)
     benchmark      = _env("BENCHMARK_SYMBOL", "SPY")
     fractional     = _env_bool("FRACTIONAL_SHARES", True)
-    data_file      = _env("DATA_FILE", "close.pkl")
-    meta_file      = _env("METADATA_FILE", "metadata.pkl")
+    data_file      = _env("DATA_FILE", "data/close.pkl")
+    meta_file      = _env("METADATA_FILE", "data/metadata.pkl")
     paper_mode     = _env_bool("ALPACA_PAPER", True)
     api_key        = _env("ALPACA_API_KEY")
     secret_key     = _env("ALPACA_SECRET_KEY")
+    data_source    = _env("DATA_SOURCE", "local")
+    cache_dir      = _env("DATA_CACHE_DIR", "data/cache/alpaca")
     run_dir        = Path(_env("RUN_STATE_DIR", "run_state"))
 
     set_account_path(account_dir)
@@ -204,12 +205,24 @@ def _run(log, audit, today: dt.date) -> int:
 
     # ── 4. Data manager ────────────────────────────────────────────────────
     try:
-        data_manager = DataManager(
-            db_file=data_file,
-            metadata_file=meta_file,
-        )
+        if data_source == "alpaca":
+            from data.alpaca import AlpacaDataManager
+            data_manager = AlpacaDataManager(
+                api_key=api_key,
+                secret_key=secret_key,
+                cache_dir=Path(cache_dir),
+            )
+            # Refresh cache before optimising — only fetches the missing tail.
+            account_tickers = list(account.portfolio.assets) + [benchmark]
+            data_manager.refresh_cache(account_tickers)
+        else:
+            from data.local import LocalDataManager
+            data_manager = LocalDataManager(
+                db_file=data_file,
+                metadata_file=meta_file,
+            )
     except Exception as exc:
-        log.error("Failed to load data manager: %s", exc)
+        log.error("Failed to initialise data manager (%s): %s", data_source, exc)
         return 1
 
     # ── 5. Generate orders via CVaR optimizer ──────────────────────────────

--- a/source/account_manager.py
+++ b/source/account_manager.py
@@ -18,183 +18,63 @@ from resources import (
     build_account_history,
 )
 from opt_tools import cvar_model_ortools, default_cvar_parameters
+from backtest import build_equity_curve, build_benchmark_curve
 
 
 def read_account(account_name):
     account = load_account(account_name)
 
 
-def benchmark2(account_name, benchmark_symbol="SPY"):
-    account = load_account(account_name)
-    portfolios = account.portfolios
-    portfolio_dates = sorted(portfolios.keys())
+def benchmark2(account_name, benchmark_symbol="SPY", save_figure=None):
+    """Plot account equity curve vs a benchmark.
 
+    The benchmark receives the same cash flows (deposits/withdrawals) as the
+    account. save_figure: path to save the plot, or None to display it.
+    """
+    account = load_account(account_name)
     data_manager = DataManager(db_file="close.pkl")
-    SPY_prices = data_manager.get_prices(benchmark_symbol)
 
-    benchmark_quantity = 0
-    account_history, history_dates, benchmark_history = [], [], []
-
-    last_valid_price = defaultdict(float)
-    last_portfolio_value = 0
-
-    for date_ix, portfolio_date in enumerate(portfolio_dates):
-        current_portfolio = portfolios[portfolio_date]
-        if not current_portfolio.assets:
-            continue
-
-        assets_data = data_manager.get_prices(current_portfolio.assets)
-        pd_date = pd.Timestamp(year=portfolio_date.year,
-                               month=portfolio_date.month,
-                               day=portfolio_date.day)
-
-        for asset in assets_data.columns:
-            price = assets_data[asset].loc[pd_date]
-            if not math.isnan(price):
-                last_valid_price[asset] = price
-
-        benchmark_price_on_date = SPY_prices.loc[pd_date]
-        if not math.isnan(benchmark_price_on_date):
-            last_valid_price[benchmark_symbol] = benchmark_price_on_date
-
-        portfolio_value = sum(
-            current_portfolio.get_position(asset) * last_valid_price[asset]
-            for asset in current_portfolio.assets
-        )
-
-        benchmark_quantity += (portfolio_value - last_portfolio_value) / \
-                              last_valid_price[benchmark_symbol]
-        last_portfolio_value = portfolio_value
-
-        start_date = dt.datetime(portfolio_date.year,
-                                 portfolio_date.month,
-                                 portfolio_date.day)
-        end_date = portfolio_dates[date_ix + 1] if date_ix + 1 < len(
-            portfolio_dates) else dt.datetime.today()
-        end_date = dt.datetime(end_date.year, end_date.month, end_date.day)
-
-        assets_data = assets_data[(assets_data.index >= start_date) &
-                                  (assets_data.index <= end_date)]
-
-        for d in assets_data.index:
-            total_assets_d = 0
-            prices_d = assets_data.loc[d]
-            for asset in prices_d.index:
-                asset_price_at_d = prices_d.loc[asset]
-                if not math.isnan(asset_price_at_d):
-                    last_valid_price[asset] = asset_price_at_d
-                total_assets_d += last_valid_price[asset] * \
-                                  current_portfolio.get_position(asset)
-
-            account_history.append(total_assets_d)
-
-            benchmark_price_on_date = SPY_prices.loc[d]
-            if not math.isnan(benchmark_price_on_date):
-                last_valid_price[benchmark_symbol] = benchmark_price_on_date
-
-            benchmark_history.append(last_valid_price[benchmark_symbol] *
-                                     benchmark_quantity)
-            history_dates.append(d)
-
-    net_transactions = {}
-    balance = 0
-    for op_date, op_value in account.operations_history():
-        balance += op_value
-        pandas_date = pd.Timestamp(year=op_date.year, month=op_date.month,
-                                   day=op_date.day)
-        net_transactions[pandas_date] = balance
-
-    transaction_dates = sorted(net_transactions.keys())
-    cummulative_transactions = [0] * len(history_dates)
-
-    for d_ix, d in enumerate(history_dates):
-        for d_transaction in transaction_dates:
-            if d > d_transaction:
-                cummulative_transactions[d_ix] = net_transactions[
-                    d_transaction]
-
-    today = dt.datetime.today()
-    cummulative_transactions = [net_transactions[d] for d in transaction_dates]
-    transaction_dates.append(pd.Timestamp(year=today.year, month=today.month,
-                                          day=today.day))
-    cummulative_transactions.append(cummulative_transactions[-1])
+    account_curve = build_equity_curve(account, data_manager)
+    bench_curve = build_benchmark_curve(account, benchmark_symbol, data_manager)
 
     fig, axes = plt.subplots(ncols=1, figsize=(12, 4))
-    axes.step(transaction_dates, cummulative_transactions, where="post",
-              color="lightblue", alpha=0.7)
-    axes.plot(history_dates, account_history, color="blue")
-    axes.plot(history_dates, benchmark_history, color="red")
+    axes.plot(account_curve.index, account_curve.values, color="blue",
+              label="Portfolio")
+    axes.plot(bench_curve.index, bench_curve.values, color="red",
+              label=benchmark_symbol)
+    axes.legend()
 
-    plt.show()
+    if save_figure:
+        fig.savefig(save_figure)
+    else:
+        plt.show()
+    return fig
 
 
-def benchmark(account_name, benchmark_symbol="SPY"):
-    """
-    Benchmarks an account against `benchmark_symbol`.
+def benchmark(account_name, benchmark_symbol="SPY", save_figure=None):
+    """Plot account equity curve vs a benchmark.
+
+    The benchmark receives the same cash flows (deposits/withdrawals) as the
+    account. save_figure: path to save the plot, or None to display it.
     """
     account = load_account(account_name)
+    data_manager = DataManager(db_file="close.pkl")
 
-    file_name = "close.pkl"
-    data_manager = DataManager(db_file=file_name)
-    sp500_stocks = dbh.get_sp500_tickers()
-
-    sp500_portfolios = {}
-    ini_portfolio = Portfolio.create_empty()
-    SPY_prices = data_manager.get_prices(benchmark_symbol)
-    net_transactions = {}
-    balance = 0
-    for op_date, op_value in account.operations_history():
-        balance += op_value
-        pandas_date = pd.Timestamp(
-            year=op_date.year, month=op_date.month, day=op_date.day
-        )
-        date_ix = np.where(SPY_prices.index == pandas_date)[0][0]
-        price_on_date = SPY_prices.iloc[date_ix][0]
-        qty_delta = op_value / price_on_date
-        current_qty = ini_portfolio.get_position(benchmark_symbol)
-        portfolio_on_date = Portfolio.create_empty()
-        portfolio_on_date.modify_position(
-            benchmark_symbol, current_qty + qty_delta
-        )
-        sp500_portfolios[op_date] = portfolio_on_date
-        ini_portfolio = sp500_portfolios[op_date]
-        net_transactions[pandas_date] = balance
-
-    history_dates, sp_500_history_values = build_account_history(
-        sp500_portfolios, data_manager
-    )
-    history_dates, history_values = build_account_history(
-        account.portfolios, data_manager
-    )
-    sp_500_history_values.insert(0, 0)
-
-    transaction_dates = list(net_transactions.keys())
-    transaction_dates.sort()
-    cummulative_transactions = [0] * len(history_dates)
-    last_date_ix = 0
-    for d_ix, d in enumerate(history_dates):
-        for d_transaction in transaction_dates:
-            if d > d_transaction:
-                cummulative_transactions[d_ix] = net_transactions[d_transaction]
-    today = dt.datetime.today()
-    cummulative_transactions = [net_transactions[d] for d in transaction_dates]
-    transaction_dates.append(
-        pd.Timestamp(year=today.year, month=today.month, day=today.day)
-    )
-    cummulative_transactions.append(cummulative_transactions[-1])
+    account_curve = build_equity_curve(account, data_manager)
+    bench_curve = build_benchmark_curve(account, benchmark_symbol, data_manager)
 
     fig, axes = plt.subplots(ncols=1, figsize=(12, 4))
-    axes.step(
-        transaction_dates,
-        cummulative_transactions,
-        where="post",
-        color="lightblue",
-        alpha=0.7,
-    )
-    axes.plot(history_dates, history_values, color="blue")
-    axes.plot(history_dates, sp_500_history_values, color="red")
+    axes.plot(account_curve.index, account_curve.values, color="blue",
+              label="Portfolio")
+    axes.plot(bench_curve.index, bench_curve.values, color="red",
+              label=benchmark_symbol)
+    axes.legend()
 
-    plt.show()
+    if save_figure:
+        fig.savefig(save_figure)
+    else:
+        plt.show()
+    return fig
 
 
 def piechart(account_name):
@@ -259,19 +139,24 @@ def rebalance_porfolio(
     end_date,
     data_file_name="close.pkl",
     metadata_file_name="metadata.pkl",
+    data_manager=None,
     print_portfolio=True,
     **kwargs,
 ):
     """
     Return the orders to be executed to rebalance the current portfolio in
     the `account`.
+
+    data_manager: optional pre-constructed DataManager (or compatible object).
+    If None, one is created from data_file_name / metadata_file_name.
     """
     base_portfolio = portfolio
 
     # Data preparation specific to `base_portfolio`. In particular
     # if an asset in the portfolio is no longer listed, it is considered
     # to have a price time series of zero.
-    data_manager = DataManager(data_file_name, metadata_file_name)
+    if data_manager is None:
+        data_manager = DataManager(data_file_name, metadata_file_name)
     returns = data_manager.get_returns(start_date, end_date)
     current_price = data_manager.get_prices(returns.columns).loc[end_date]
     for asset in base_portfolio.assets:

--- a/source/backtest.py
+++ b/source/backtest.py
@@ -1,0 +1,392 @@
+"""Walk-forward backtesting and portfolio performance analysis.
+
+Public API:
+    BacktestConfig       — configuration for run_backtest
+    BacktestResult       — output of run_backtest
+    build_equity_curve   — daily total value (equity + cash) from an Account
+    build_benchmark_curve— daily benchmark value matching account cash flows
+    compute_metrics      — Sharpe, Sortino, max drawdown, Calmar, info ratio
+    run_backtest         — schedule-driven walk-forward simulation
+"""
+import datetime as dt
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from opt_tools import CvarParameters, cvar_model_ortools, default_cvar_parameters
+from resources import (
+    OPERATION_BUY,
+    OPERATION_SELL,
+    Account,
+    Order,
+    Portfolio,
+    build_account_history,
+    generate_orders,
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration and result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BacktestConfig:
+    """Configuration for a schedule-driven walk-forward backtest."""
+    rebalance_schedule: List[dt.datetime]
+    lookback_days: int = 504
+    initial_cash: float = 100_000.0
+    transaction_cost_bps: float = 5.0
+    cvar_params: Optional[CvarParameters] = None
+    fractional_shares: bool = True
+    universe: Optional[List[str]] = None
+    # Max total shares that may be reduced across all positions per rebalance.
+    # None = no restriction (full rebalancing allowed).
+    portfolio_delta: Optional[float] = None
+
+
+@dataclass
+class BacktestResult:
+    """Output of a walk-forward backtest."""
+    equity_curve: pd.Series
+    benchmark_curve: pd.Series
+    trades: pd.DataFrame
+    metrics: Dict
+    account: Account
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _to_ts(d) -> pd.Timestamp:
+    return pd.Timestamp(d)
+
+
+def _cash_at_date(account: Account, target_date) -> float:
+    """Reconstruct cash balance at any historical date.
+
+    Sums deposits/withdrawals from cash_flow and buy/sell costs from
+    transactions that occurred on or before target_date.
+    """
+    target_ts = _to_ts(target_date)
+    cash = 0.0
+    for _, row in account.cash_flow.iterrows():
+        if _to_ts(row["datetime"]) <= target_ts:
+            cash += row["amount"] if row["type"] == "deposit" else -row["amount"]
+    for _, row in account.transactions.iterrows():
+        if _to_ts(row["datetime"]) <= target_ts:
+            if row["operation"] == OPERATION_BUY:
+                cash -= row["qty"] * row["price"]
+            elif row["operation"] == OPERATION_SELL:
+                cash += row["qty"] * row["price"]
+    return cash
+
+
+# ---------------------------------------------------------------------------
+# Core analysis functions
+# ---------------------------------------------------------------------------
+
+def build_equity_curve(account: Account, data_manager) -> pd.Series:
+    """Daily time series of total account value: equity + cash.
+
+    Cash is reconstructed at each portfolio-snapshot date from the account's
+    cash_flow (deposits/withdrawals) and transactions (buy/sell costs).
+    Unlike the legacy build_account_history, this includes uninvested cash so
+    the curve correctly reflects deposits, partial deployment, and withdrawals.
+
+    Args:
+        account: Account with portfolios, cash_flow, and transactions history.
+        data_manager: object with get_prices(assets) returning a DataFrame.
+
+    Returns:
+        pd.Series indexed by date with name "portfolio_value".
+    """
+    portfolio_dates = sorted(account.portfolios.keys())
+    all_dates: List = []
+    all_values: List[float] = []
+    last_valid: Dict[str, float] = defaultdict(float)
+
+    for date_ix, tx_date in enumerate(portfolio_dates):
+        portfolio = account.portfolios[tx_date]
+        if not portfolio.assets:
+            continue
+
+        cash = _cash_at_date(account, tx_date)
+        end_date = (
+            portfolio_dates[date_ix + 1]
+            if date_ix + 1 < len(portfolio_dates)
+            else dt.datetime.today()
+        )
+
+        assets = list(portfolio.assets)
+        prices_df = data_manager.get_prices(assets)
+        if isinstance(prices_df, pd.Series):
+            prices_df = prices_df.to_frame()
+
+        start_ts, end_ts = _to_ts(tx_date), _to_ts(end_date)
+        slice_ = prices_df[(prices_df.index >= start_ts) & (prices_df.index < end_ts)]
+
+        for d in slice_.index:
+            equity = 0.0
+            for asset in assets:
+                p = float(slice_.loc[d, asset])
+                if not math.isnan(p):
+                    last_valid[asset] = p
+                equity += last_valid[asset] * portfolio.get_position(asset)
+            all_dates.append(d)
+            all_values.append(equity + cash)
+
+    return pd.Series(all_values, index=all_dates, name="portfolio_value")
+
+
+def build_benchmark_curve(
+    account: Account, benchmark_symbol: str, data_manager
+) -> pd.Series:
+    """Daily benchmark portfolio value that mirrors the account's cash flows.
+
+    For each deposit in account.cash_flow, the benchmark buys
+    (deposit / benchmark_price) shares of benchmark_symbol.  For each
+    withdrawal, it sells the equivalent amount.  Rebalances (sell A / buy B)
+    involve no new external cash so the benchmark is unaffected — giving a
+    fair "what if I had just bought SPY" comparison.
+
+    Args:
+        account:          Account whose cash_flow drives the benchmark.
+        benchmark_symbol: Ticker to use as the benchmark (e.g. "SPY").
+        data_manager:     object with get_prices(assets) returning a DataFrame.
+
+    Returns:
+        pd.Series indexed by date with name benchmark_symbol.
+    """
+    if account.cash_flow.empty:
+        return pd.Series(dtype=float, name=benchmark_symbol)
+
+    bench_prices = data_manager.get_prices(benchmark_symbol)
+    if isinstance(bench_prices, pd.DataFrame):
+        bench_prices = bench_prices.iloc[:, 0]
+
+    bench_qty = 0.0
+    bench_portfolios: Dict = {}
+
+    for _, row in account.cash_flow.sort_values("datetime").iterrows():
+        flow_ts = _to_ts(row["datetime"])
+        delta = row["amount"] if row["type"] == "deposit" else -row["amount"]
+
+        # Use the price on or after the cash-flow date.
+        future = bench_prices[bench_prices.index >= flow_ts]
+        if future.empty:
+            continue
+        price = float(future.iloc[0])
+        if math.isnan(price) or price <= 0:
+            continue
+
+        bench_qty += delta / price
+        p = Portfolio.create_empty()
+        if bench_qty > 0:
+            p.modify_position(benchmark_symbol, bench_qty)
+        bench_portfolios[row["datetime"]] = p
+
+    if not bench_portfolios:
+        return pd.Series(dtype=float, name=benchmark_symbol)
+
+    dates_list, values_list = build_account_history(bench_portfolios, data_manager)
+    return pd.Series(values_list, index=dates_list, name=benchmark_symbol)
+
+
+def compute_metrics(
+    equity_curve: pd.Series,
+    benchmark_curve: Optional[pd.Series] = None,
+    risk_free_rate: float = 0.0,
+) -> Dict:
+    """Compute standard risk/return metrics from a daily equity curve.
+
+    Args:
+        equity_curve:    Daily portfolio values (pd.Series indexed by date).
+        benchmark_curve: Optional daily benchmark values for relative metrics.
+        risk_free_rate:  Annualised risk-free rate (e.g. 0.05 = 5 %).
+
+    Returns dict with keys: total_return, annualized_return, annualized_vol,
+    sharpe, sortino, max_drawdown, calmar, and information_ratio (if benchmark
+    is provided).
+    """
+    if len(equity_curve) < 2:
+        return {}
+
+    daily_ret = equity_curve.pct_change().dropna()
+    ann = 252
+    daily_rf = risk_free_rate / ann
+
+    total_return = float(equity_curve.iloc[-1] / equity_curve.iloc[0] - 1)
+    n_years = len(daily_ret) / ann
+    ann_return = float((1 + total_return) ** (1 / max(n_years, 1e-9)) - 1)
+    ann_vol = float(daily_ret.std()) * math.sqrt(ann)
+
+    excess = daily_ret - daily_rf
+    sharpe = (
+        float(excess.mean()) / float(excess.std()) * math.sqrt(ann)
+        if float(excess.std()) > 0 else 0.0
+    )
+
+    downside = excess[excess < 0]
+    down_std = float(downside.std()) * math.sqrt(ann) if len(downside) > 1 else 0.0
+    sortino = (ann_return - risk_free_rate) / down_std if down_std > 0 else 0.0
+
+    rolling_max = equity_curve.cummax()
+    drawdowns = (equity_curve - rolling_max) / rolling_max
+    max_drawdown = float(drawdowns.min())
+
+    calmar = ann_return / abs(max_drawdown) if max_drawdown < 0 else 0.0
+
+    metrics: Dict = {
+        "total_return": total_return,
+        "annualized_return": ann_return,
+        "annualized_vol": ann_vol,
+        "sharpe": sharpe,
+        "sortino": sortino,
+        "max_drawdown": max_drawdown,
+        "calmar": calmar,
+    }
+
+    if benchmark_curve is not None and len(benchmark_curve) >= 2:
+        bench_ret = benchmark_curve.pct_change().dropna()
+        common = daily_ret.index.intersection(bench_ret.index)
+        if len(common) > 1:
+            alpha = daily_ret[common] - bench_ret[common]
+            ir = (
+                float(alpha.mean()) / float(alpha.std()) * math.sqrt(ann)
+                if float(alpha.std()) > 0 else 0.0
+            )
+            metrics["information_ratio"] = ir
+
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward backtest
+# ---------------------------------------------------------------------------
+
+def run_backtest(
+    config: BacktestConfig,
+    data_manager,
+    benchmark_symbol: str = "SPY",
+) -> BacktestResult:
+    """Schedule-driven walk-forward backtest.
+
+    On each date in config.rebalance_schedule the CVaR optimizer is called
+    with the returns from [rebalance_date - lookback_days, rebalance_date].
+    Orders are filled via CostAwarePaperBroker and the simulated Account is
+    updated with actual fill prices.
+
+    Args:
+        config:           BacktestConfig describing the simulation.
+        data_manager:     DataManager (or FakeDataManager) for price data.
+        benchmark_symbol: Ticker used as the passive benchmark.
+
+    Returns:
+        BacktestResult with equity curve, benchmark curve, trades, metrics,
+        and the full simulated Account.
+    """
+    from broker.paper import CostAwarePaperBroker
+
+    cvar_params = config.cvar_params or default_cvar_parameters()
+    schedule = sorted(config.rebalance_schedule)
+
+    account = Account("backtest", schedule[0])
+    account.deposit(schedule[0], config.initial_cash)
+    broker = CostAwarePaperBroker(cost_bps=config.transaction_cost_bps)
+
+    for rebalance_date in schedule:
+        lookback_start = rebalance_date - dt.timedelta(days=config.lookback_days)
+        universe = config.universe or []
+
+        try:
+            returns = data_manager.get_returns(lookback_start, rebalance_date, stocks=universe)
+        except Exception:
+            continue
+
+        if returns is None or returns.empty or len(returns.columns) < 2:
+            continue
+
+        prices_df = data_manager.get_prices(list(returns.columns))
+        if isinstance(prices_df, pd.Series):
+            prices_df = prices_df.to_frame()
+        rebalance_ts = _to_ts(rebalance_date)
+        if rebalance_ts in prices_df.index:
+            current_price = prices_df.loc[rebalance_ts]
+        else:
+            past = prices_df[prices_df.index <= rebalance_ts]
+            if past.empty:
+                continue
+            current_price = past.iloc[-1]
+
+        portfolio = account.portfolio
+        for asset in list(portfolio.assets):
+            if asset not in current_price.index:
+                current_price[asset] = 0.0
+            if asset not in returns.columns:
+                returns = returns.copy()
+                returns[asset] = np.zeros(len(returns))
+
+        total_value = account.cash_onhand + sum(
+            float(current_price.get(a, 0)) * portfolio.get_position(a)
+            for a in portfolio.assets
+        )
+        portfolio_delta = (
+            config.portfolio_delta
+            if config.portfolio_delta is not None
+            else total_value  # no sell restriction
+        )
+
+        try:
+            opt_model = cvar_model_ortools(
+                cvar_params,
+                np.array(returns),
+                current_price,
+                current_portfolio=portfolio,
+                budget=account.cash_onhand,
+                fractional=config.fractional_shares,
+                portfolio_delta=portfolio_delta,
+            )
+            cvar_sol, _ = opt_model.change_cvar_params(cvar_beta=cvar_params.beta)
+        except Exception:
+            continue
+
+        new_df = cvar_sol[cvar_sol.qty > 0]
+        if new_df.empty:
+            continue
+
+        new_port = Portfolio.create_from_vectors(
+            new_df.index.tolist(), new_df.qty.tolist()
+        )
+        orders = generate_orders(portfolio, new_port, current_price)
+        if not orders:
+            continue
+
+        fills = []
+        for order in orders:
+            try:
+                oid = broker.submit_order(order)
+                fill = broker.get_fill(oid)
+                if fill:
+                    fills.append(fill)
+            except ValueError:
+                continue
+
+        if fills:
+            account.update_account_from_fills(rebalance_date, fills)
+
+    equity_curve = build_equity_curve(account, data_manager)
+    benchmark_curve = build_benchmark_curve(account, benchmark_symbol, data_manager)
+    metrics = compute_metrics(equity_curve, benchmark_curve)
+
+    return BacktestResult(
+        equity_curve=equity_curve,
+        benchmark_curve=benchmark_curve,
+        trades=account.transactions.copy(),
+        metrics=metrics,
+        account=account,
+    )

--- a/source/broker/__init__.py
+++ b/source/broker/__init__.py
@@ -1,0 +1,4 @@
+from broker.base import BrokerBase
+from broker.paper import PaperBroker
+
+__all__ = ["BrokerBase", "PaperBroker"]

--- a/source/broker/alpaca.py
+++ b/source/broker/alpaca.py
@@ -1,0 +1,98 @@
+"""Alpaca broker integration using the alpaca-py SDK.
+
+Install the dependency with:
+    pip install alpaca-py
+
+API keys are read from constructor arguments. Load them from environment
+variables or a secrets manager — never hard-code them:
+
+    import os
+    broker = AlpacaBroker(
+        api_key=os.environ["ALPACA_API_KEY"],
+        secret_key=os.environ["ALPACA_SECRET_KEY"],
+        paper=True,  # set False for live trading
+    )
+"""
+from typing import Optional
+
+from broker.base import BrokerBase
+from resources import Fill, Order, Portfolio, OPERATION_BUY, OPERATION_SELL
+
+try:
+    from alpaca.trading.client import TradingClient
+    from alpaca.trading.enums import OrderSide, OrderStatus, TimeInForce
+    from alpaca.trading.requests import MarketOrderRequest
+    _ALPACA_AVAILABLE = True
+except ImportError:
+    _ALPACA_AVAILABLE = False
+
+
+class AlpacaBroker(BrokerBase):
+    """Broker implementation backed by the Alpaca Trading API.
+
+    Supports paper trading (paper=True, default) and live trading (paper=False).
+    Always start with paper=True and validate the full execution loop before
+    switching to live.
+    """
+
+    def __init__(self, api_key: str, secret_key: str, paper: bool = True):
+        if not _ALPACA_AVAILABLE:
+            raise ImportError(
+                "alpaca-py is required. Install it with: pip install alpaca-py"
+            )
+        self._client = TradingClient(api_key, secret_key, paper=paper)
+        self._paper = paper
+
+    def submit_order(self, order: Order) -> str:
+        """Submit a market order and return the Alpaca order ID."""
+        side = OrderSide.BUY if order.operation_type == OPERATION_BUY else OrderSide.SELL
+        request = MarketOrderRequest(
+            symbol=order.ticker,
+            qty=order.qty,
+            side=side,
+            time_in_force=TimeInForce.DAY,
+        )
+        alpaca_order = self._client.submit_order(request)
+        return str(alpaca_order.id)
+
+    def get_fill(self, order_id: str) -> Optional[Fill]:
+        """Return a Fill once the order is fully filled, None if still pending."""
+        alpaca_order = self._client.get_order_by_id(order_id)
+        if alpaca_order.status != OrderStatus.FILLED:
+            return None
+        side = (
+            OPERATION_BUY
+            if alpaca_order.side == OrderSide.BUY
+            else OPERATION_SELL
+        )
+        return Fill(
+            ticker=alpaca_order.symbol,
+            qty=float(alpaca_order.filled_qty),
+            fill_price=float(alpaca_order.filled_avg_price),
+            operation_type=side,
+            fill_time=alpaca_order.filled_at,
+            broker_order_id=order_id,
+        )
+
+    def get_positions(self) -> Portfolio:
+        """Return current Alpaca positions as a Portfolio."""
+        positions = self._client.get_all_positions()
+        portfolio = Portfolio.create_empty()
+        for pos in positions:
+            qty = float(pos.qty)
+            if qty > 0:
+                portfolio.modify_position(pos.symbol, qty)
+        return portfolio
+
+    def cancel_order(self, order_id: str) -> bool:
+        """Cancel an open order. Returns True if the cancellation succeeded."""
+        try:
+            self._client.cancel_order_by_id(order_id)
+            return True
+        except Exception:
+            return False
+
+    def is_market_open(self) -> bool:
+        """Return True if the NYSE is currently open for trading."""
+        clock = self._client.get_clock()
+        return clock.is_open

--- a/source/broker/base.py
+++ b/source/broker/base.py
@@ -1,0 +1,53 @@
+import time
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from resources import Fill, Order, Portfolio
+
+
+class BrokerBase(ABC):
+    """Abstract interface for broker integrations.
+
+    Concrete implementations: AlpacaBroker (live/paper API) and
+    PaperBroker (in-memory, for testing and backtesting).
+    """
+
+    @abstractmethod
+    def submit_order(self, order: Order) -> str:
+        """Submit an order and return the broker-assigned order ID."""
+
+    @abstractmethod
+    def get_fill(self, order_id: str) -> Optional[Fill]:
+        """Return a Fill if the order is fully filled, None if still pending."""
+
+    @abstractmethod
+    def get_positions(self) -> Portfolio:
+        """Return current holdings as a Portfolio."""
+
+    @abstractmethod
+    def cancel_order(self, order_id: str) -> bool:
+        """Cancel an open order. Returns True if the cancellation succeeded."""
+
+    @abstractmethod
+    def is_market_open(self) -> bool:
+        """Return True if the market is currently open for trading."""
+
+    def submit_and_await_fill(
+        self,
+        order: Order,
+        timeout_seconds: int = 60,
+        poll_interval: int = 2,
+    ) -> Optional[Fill]:
+        """Submit an order and poll until filled or timeout expires.
+
+        Returns the Fill on success, None if timeout is reached.
+        """
+        order_id = self.submit_order(order)
+        elapsed = 0
+        while elapsed < timeout_seconds:
+            fill = self.get_fill(order_id)
+            if fill is not None:
+                return fill
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+        return None

--- a/source/broker/paper.py
+++ b/source/broker/paper.py
@@ -58,3 +58,33 @@ class PaperBroker(BrokerBase):
     def set_market_open(self, is_open: bool) -> None:
         """Test helper: simulate market open/closed state."""
         self._market_open = is_open
+
+
+class CostAwarePaperBroker(PaperBroker):
+    """PaperBroker that applies a bid-ask spread haircut to each fill price.
+
+    Buys are filled at  price * (1 + cost_bps / 10_000).
+    Sells are filled at price * (1 - cost_bps / 10_000).
+    The position qty is unchanged; the cost is captured in the fill price
+    and therefore in the cash accounting when Account.update_account_from_fills
+    is called.
+    """
+
+    def __init__(
+        self,
+        cost_bps: float = 5.0,
+        initial_portfolio: Optional[Portfolio] = None,
+    ):
+        super().__init__(initial_portfolio=initial_portfolio)
+        self._cost_bps = cost_bps
+
+    def submit_order(self, order: Order) -> str:
+        cost_factor = self._cost_bps / 10_000
+        if order.operation_type == OPERATION_BUY:
+            adjusted_price = order.price * (1 + cost_factor)
+        elif order.operation_type == OPERATION_SELL:
+            adjusted_price = order.price * (1 - cost_factor)
+        else:
+            adjusted_price = order.price
+        adjusted = Order(order.ticker, order.qty, adjusted_price, order.operation_type)
+        return super().submit_order(adjusted)

--- a/source/broker/paper.py
+++ b/source/broker/paper.py
@@ -1,0 +1,60 @@
+import datetime as dt
+from typing import Dict, Optional
+
+from broker.base import BrokerBase
+from resources import Fill, Order, Portfolio, OPERATION_BUY, OPERATION_SELL
+
+
+class PaperBroker(BrokerBase):
+    """In-memory broker that fills orders instantly at the order price.
+
+    No network calls, no credentials. Used for hermetic testing and
+    for driving the walk-forward backtester.
+    """
+
+    def __init__(self, initial_portfolio: Optional[Portfolio] = None):
+        self._portfolio = initial_portfolio or Portfolio.create_empty()
+        self._fills: Dict[str, Fill] = {}
+        self._next_id = 0
+        self._market_open = True
+
+    def submit_order(self, order: Order) -> str:
+        """Fill the order immediately at order.price and update positions."""
+        if order.operation_type not in (OPERATION_BUY, OPERATION_SELL):
+            raise ValueError(f"Unsupported operation type: {order.operation_type}")
+
+        new_portfolio = Portfolio.create_from_transaction(self._portfolio, [order])
+        if new_portfolio is None:
+            raise ValueError(
+                f"Invalid order {order}: sell quantity may exceed current holdings."
+            )
+        self._portfolio = new_portfolio
+
+        self._next_id += 1
+        order_id = f"paper-{self._next_id}"
+        self._fills[order_id] = Fill(
+            ticker=order.ticker,
+            qty=order.qty,
+            fill_price=order.price,
+            operation_type=order.operation_type,
+            fill_time=dt.datetime.now(),
+            broker_order_id=order_id,
+        )
+        return order_id
+
+    def get_fill(self, order_id: str) -> Optional[Fill]:
+        return self._fills.get(order_id)
+
+    def get_positions(self) -> Portfolio:
+        return self._portfolio
+
+    def cancel_order(self, order_id: str) -> bool:
+        # PaperBroker fills are immediate; there is nothing left to cancel.
+        return False
+
+    def is_market_open(self) -> bool:
+        return self._market_open
+
+    def set_market_open(self, is_open: bool) -> None:
+        """Test helper: simulate market open/closed state."""
+        self._market_open = is_open

--- a/source/data/__init__.py
+++ b/source/data/__init__.py
@@ -1,0 +1,11 @@
+from data.base import DataManagerBase, EMPTY_METADATA, quotient_diff
+from data.local import LocalDataManager
+from data.alpaca import AlpacaDataManager
+
+__all__ = [
+    "DataManagerBase",
+    "EMPTY_METADATA",
+    "quotient_diff",
+    "LocalDataManager",
+    "AlpacaDataManager",
+]

--- a/source/data/alpaca.py
+++ b/source/data/alpaca.py
@@ -145,21 +145,39 @@ class AlpacaDataManager(DataManagerBase):
         self,
         tickers: List[str],
         end_date=None,
+        force: bool = False,
     ) -> None:
         """Fetch missing price history for *tickers* and update the cache.
 
-        Only the tail that is absent from each ticker's parquet file is
-        fetched from Alpaca.  For a warm cache (daily run) this is typically
-        one trading day per ticker, resolved in a single bulk API call.
+        This is called by run_daily.py once per trading day, before the CVaR
+        optimiser runs.  It finds the last cached date for each ticker and
+        fetches only the missing tail from Alpaca in a single bulk API call.
+        For a warm cache this is typically one row per ticker.
+
+        Corporate actions (splits, spin-offs) invalidate historical adjusted-
+        close prices retroactively.  When Alpaca re-issues corrected bars the
+        cached series becomes inconsistent at the join point.  Pass
+        ``force=True`` for any affected tickers to delete their cache files
+        and re-download the full history from _DEFAULT_HISTORY_START.
 
         Args:
             tickers:  List of ticker symbols to refresh.
             end_date: Last date to fetch (inclusive).  Defaults to yesterday
                       so we never request an incomplete trading day.
+            force:    If True, delete the existing cache file for each ticker
+                      before fetching, forcing a full re-download.  Use after
+                      a stock split or other corporate action.
         """
         if end_date is None:
             end_date = dt.date.today() - dt.timedelta(days=1)
         end_date = _to_date(end_date)
+
+        if force:
+            for ticker in tickers:
+                path = self._cache_path(ticker)
+                if path.exists():
+                    path.unlink()
+                    log.info("Deleted cache for %s (force=True).", ticker)
 
         # Determine the fetch window for each ticker.
         fetch_start: dict[str, dt.date] = {}
@@ -246,8 +264,12 @@ class AlpacaDataManager(DataManagerBase):
             DataFrame with DatetimeIndex and ticker columns.
         """
         if assets is None:
-            # Return all cached tickers.
             assets = [p.stem for p in self._cache_dir.glob("*.parquet")]
+            if not assets:
+                raise RuntimeError(
+                    f"No parquet cache files found in '{self._cache_dir}'. "
+                    "Call refresh_cache() before get_prices()."
+                )
 
         if isinstance(assets, str):
             assets = [assets]
@@ -266,33 +288,6 @@ class AlpacaDataManager(DataManagerBase):
             return pd.DataFrame()
 
         return pd.DataFrame(frames).sort_index()
-
-    def get_returns(
-        self,
-        start_date,
-        end_date,
-        stocks=None,
-        outlier_return: float = 10,
-    ) -> pd.DataFrame:
-        stocks = stocks or []
-        assets = stocks if stocks else None
-        prices = self.get_prices(assets)
-
-        if prices.empty:
-            return pd.DataFrame()
-
-        # Filter to the requested date window.
-        start_ts = pd.Timestamp(start_date)
-        end_ts = pd.Timestamp(end_date)
-        prices = prices[(prices.index >= start_ts) & (prices.index <= end_ts)]
-        prices = prices.dropna(axis=0, how="all").dropna(axis=1)
-
-        if len(prices) < 2:
-            return pd.DataFrame()
-
-        returns = prices.apply(quotient_diff, axis=0)
-        returns = returns[returns < outlier_return].dropna(axis=0)
-        return returns
 
     def get_metadata(self, asset: str) -> dict:
         """Return asset name and exchange from Alpaca; sector is unavailable.

--- a/source/data/alpaca.py
+++ b/source/data/alpaca.py
@@ -1,0 +1,318 @@
+"""AlpacaDataManager — market data via Alpaca + local parquet cache.
+
+Architecture
+------------
+Historical price data is stored in a per-ticker parquet cache:
+
+    cache_dir/
+        AAPL.parquet   # DatetimeIndex, single column "close" (adjusted)
+        MSFT.parquet
+        SPY.parquet
+        ...
+
+refresh_cache(tickers, end_date)
+    Called once per day (before the optimiser runs).  Finds the last cached
+    date for each ticker, fetches only the missing tail from Alpaca in a
+    single bulk API call, and appends to each file.  For a warm cache this
+    fetches one row per ticker — equivalent latency to the old pickle update.
+
+get_prices / get_returns
+    Read entirely from the parquet cache.  No network call on the hot path.
+
+get_metadata
+    Returns name + exchange from Alpaca's asset endpoint.  Sector and
+    market_cap are not available from Alpaca; those fields return "Unknown".
+
+Dependency injection
+--------------------
+Pass _data_client= and _trading_client= in the constructor to supply mock
+clients for testing without real API credentials.
+"""
+import datetime as dt
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+from data.base import DataManagerBase, EMPTY_METADATA, quotient_diff
+
+log = logging.getLogger(__name__)
+
+# Default start date for a cold-cache fetch (no prior history on disk).
+_DEFAULT_HISTORY_START = dt.date(2015, 1, 1)
+
+
+def _to_date(value) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, pd.Timestamp):
+        return value.date()
+    return value
+
+
+class AlpacaDataManager(DataManagerBase):
+    """Alpaca Market Data API backed by a local parquet cache.
+
+    Args:
+        api_key:        Alpaca API key (same key used for trading).
+        secret_key:     Alpaca secret key.
+        cache_dir:      Directory for per-ticker parquet files.
+                        Created automatically if absent.
+        _data_client:   Override the StockHistoricalDataClient (testing).
+        _trading_client:Override the TradingClient used for get_metadata
+                        (testing).  Pass None to skip metadata lookups.
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        secret_key: str = "",
+        cache_dir: Path = Path("data/cache/alpaca"),
+        _data_client=None,
+        _trading_client=None,
+    ):
+        self._cache_dir = Path(cache_dir)
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._meta_cache: dict = {}
+
+        if _data_client is not None:
+            self._data_client = _data_client
+        else:
+            try:
+                from alpaca.data.historical import StockHistoricalDataClient
+                self._data_client = StockHistoricalDataClient(api_key, secret_key)
+            except ImportError:
+                raise ImportError(
+                    "alpaca-py is required for AlpacaDataManager. "
+                    "Install it with: pip install alpaca-py"
+                )
+
+        # Trading client for get_metadata; optional — skip if not provided.
+        if _trading_client is not None:
+            self._trading_client = _trading_client
+        elif api_key:
+            try:
+                from alpaca.trading.client import TradingClient
+                self._trading_client = TradingClient(api_key, secret_key, paper=True)
+            except Exception:
+                self._trading_client = None
+        else:
+            self._trading_client = None
+
+    # ------------------------------------------------------------------
+    # Cache management
+    # ------------------------------------------------------------------
+
+    def _cache_path(self, ticker: str) -> Path:
+        return self._cache_dir / f"{ticker}.parquet"
+
+    def _read_cache(self, ticker: str) -> Optional[pd.DataFrame]:
+        """Return cached DataFrame for *ticker*, or None if not cached."""
+        path = self._cache_path(ticker)
+        if not path.exists():
+            return None
+        return pd.read_parquet(path)
+
+    def _build_bars_request(self, tickers, start, end):
+        """Build a StockBarsRequest, falling back to SimpleNamespace for testing."""
+        try:
+            from alpaca.data.requests import StockBarsRequest
+            from alpaca.data.timeframe import TimeFrame
+            from alpaca.data.enums import Adjustment
+            return StockBarsRequest(
+                symbol_or_symbols=tickers,
+                timeframe=TimeFrame.Day,
+                start=start,
+                end=end,
+                adjustment=Adjustment.ALL,
+            )
+        except ImportError:
+            from types import SimpleNamespace
+            return SimpleNamespace(
+                symbol_or_symbols=tickers, start=start, end=end
+            )
+
+    def _write_cache(self, ticker: str, df: pd.DataFrame) -> None:
+        """Atomically write *df* to the ticker's parquet file."""
+        path = self._cache_path(ticker)
+        tmp = path.with_suffix(".parquet.tmp")
+        df.to_parquet(tmp)
+        tmp.replace(path)   # atomic on same filesystem
+
+    def refresh_cache(
+        self,
+        tickers: List[str],
+        end_date=None,
+    ) -> None:
+        """Fetch missing price history for *tickers* and update the cache.
+
+        Only the tail that is absent from each ticker's parquet file is
+        fetched from Alpaca.  For a warm cache (daily run) this is typically
+        one trading day per ticker, resolved in a single bulk API call.
+
+        Args:
+            tickers:  List of ticker symbols to refresh.
+            end_date: Last date to fetch (inclusive).  Defaults to yesterday
+                      so we never request an incomplete trading day.
+        """
+        if end_date is None:
+            end_date = dt.date.today() - dt.timedelta(days=1)
+        end_date = _to_date(end_date)
+
+        # Determine the fetch window for each ticker.
+        fetch_start: dict[str, dt.date] = {}
+        for ticker in tickers:
+            cached = self._read_cache(ticker)
+            if cached is None or cached.empty:
+                fetch_start[ticker] = _DEFAULT_HISTORY_START
+            else:
+                last = _to_date(cached.index[-1])
+                if last < end_date:
+                    # Start one calendar day after the last cached date.
+                    fetch_start[ticker] = last + dt.timedelta(days=1)
+                # else: already up-to-date; skip
+
+        if not fetch_start:
+            log.debug("Cache already up-to-date for all %d tickers.", len(tickers))
+            return
+
+        # One bulk call from the earliest needed start date.
+        bulk_start = min(fetch_start.values())
+        log.info(
+            "Fetching %d ticker(s) from Alpaca: %s → %s",
+            len(fetch_start), bulk_start, end_date,
+        )
+
+        try:
+            request = self._build_bars_request(
+                list(fetch_start.keys()),
+                dt.datetime.combine(bulk_start, dt.time.min),
+                dt.datetime.combine(end_date, dt.time.max),
+            )
+            bars = self._data_client.get_stock_bars(request)
+            raw = bars.df  # MultiIndex (symbol, timestamp)
+        except Exception as exc:
+            log.error("Alpaca data fetch failed: %s", exc)
+            raise
+
+        if raw.empty:
+            log.warning("Alpaca returned no data for the requested range.")
+            return
+
+        # Append new rows to each ticker's parquet file.
+        symbols_returned = raw.index.get_level_values("symbol").unique()
+        for ticker in fetch_start:
+            if ticker not in symbols_returned:
+                log.warning("Alpaca returned no data for %s.", ticker)
+                continue
+
+            new_rows = (
+                raw.loc[ticker][["close"]]
+                .rename_axis("timestamp")
+            )
+            new_rows.index = pd.DatetimeIndex(new_rows.index).normalize()
+
+            # Drop rows earlier than the ticker's personal fetch start.
+            ticker_start = pd.Timestamp(fetch_start[ticker])
+            new_rows = new_rows[new_rows.index >= ticker_start]
+
+            cached = self._read_cache(ticker)
+            if cached is not None and not cached.empty:
+                new_rows = new_rows[new_rows.index > cached.index[-1]]
+                combined = pd.concat([cached, new_rows]).sort_index()
+            else:
+                combined = new_rows.sort_index()
+
+            combined = combined[~combined.index.duplicated(keep="last")]
+            self._write_cache(ticker, combined)
+            log.debug("Cached %d new rows for %s.", len(new_rows), ticker)
+
+    # ------------------------------------------------------------------
+    # DataManagerBase implementation
+    # ------------------------------------------------------------------
+
+    def get_prices(self, assets=None) -> pd.DataFrame:
+        """Read adjusted close prices from the parquet cache.
+
+        Does NOT fetch from Alpaca — call refresh_cache() first to ensure
+        the cache is current.
+
+        Args:
+            assets: ticker string, list of tickers, or None for all cached.
+
+        Returns:
+            DataFrame with DatetimeIndex and ticker columns.
+        """
+        if assets is None:
+            # Return all cached tickers.
+            assets = [p.stem for p in self._cache_dir.glob("*.parquet")]
+
+        if isinstance(assets, str):
+            assets = [assets]
+
+        frames = {}
+        for ticker in assets:
+            cached = self._read_cache(ticker)
+            if cached is None or cached.empty:
+                log.warning(
+                    "No cached data for %s. Call refresh_cache() first.", ticker
+                )
+                continue
+            frames[ticker] = cached["close"]
+
+        if not frames:
+            return pd.DataFrame()
+
+        return pd.DataFrame(frames).sort_index()
+
+    def get_returns(
+        self,
+        start_date,
+        end_date,
+        stocks=None,
+        outlier_return: float = 10,
+    ) -> pd.DataFrame:
+        stocks = stocks or []
+        assets = stocks if stocks else None
+        prices = self.get_prices(assets)
+
+        if prices.empty:
+            return pd.DataFrame()
+
+        # Filter to the requested date window.
+        start_ts = pd.Timestamp(start_date)
+        end_ts = pd.Timestamp(end_date)
+        prices = prices[(prices.index >= start_ts) & (prices.index <= end_ts)]
+        prices = prices.dropna(axis=0, how="all").dropna(axis=1)
+
+        if len(prices) < 2:
+            return pd.DataFrame()
+
+        returns = prices.apply(quotient_diff, axis=0)
+        returns = returns[returns < outlier_return].dropna(axis=0)
+        return returns
+
+    def get_metadata(self, asset: str) -> dict:
+        """Return asset name and exchange from Alpaca; sector is unavailable.
+
+        Alpaca's market data API does not provide sector or market cap.
+        Those fields are returned as empty strings / 0.  Use LocalDataManager
+        or supplement with another provider if fundamentals are required.
+        """
+        if asset in self._meta_cache:
+            return self._meta_cache[asset]
+
+        meta = {**EMPTY_METADATA, "name": asset}
+
+        if self._trading_client is not None:
+            try:
+                asset_info = self._trading_client.get_asset(asset)
+                meta["name"] = asset_info.name or asset
+                meta["sector"] = getattr(asset_info, "exchange", "") or ""
+            except Exception as exc:
+                log.debug("Could not fetch metadata for %s from Alpaca: %s", asset, exc)
+
+        self._meta_cache[asset] = meta
+        return meta

--- a/source/data/base.py
+++ b/source/data/base.py
@@ -1,0 +1,84 @@
+"""Abstract base class for all market data providers.
+
+Every concrete implementation must satisfy the three-method contract used
+throughout the codebase (backtest.py, account_manager.py, run_daily.py).
+FakeDataManager in tests/ also subclasses this so type-checking catches drift.
+"""
+from abc import ABC, abstractmethod
+
+import numpy as np
+import pandas as pd
+
+
+def quotient_diff(series: pd.Series) -> pd.Series:
+    """Compute gross return ratios: price[t+1] / price[t].
+
+    A value of 1.05 means +5%; 0.95 means -5%.  This is the return
+    representation used throughout the CVaR optimiser.
+    """
+    y = np.array(series)
+    return pd.Series(y[1:] / y[:-1], index=series.index[1:])
+
+
+EMPTY_METADATA = {
+    "name": "",
+    "sector": "",
+    "subsector": "",
+    "market_cap": 0,
+}
+
+
+class DataManagerBase(ABC):
+    """Contract that every data provider must implement.
+
+    All three methods are used by backtest.py, account_manager.py, and
+    run_daily.py.  The FakeDataManager in tests/ satisfies the same interface
+    so unit tests remain hermetic.
+
+    get_prices  — full price history for the requested tickers
+    get_returns — gross-return ratios for a date window, outliers removed
+    get_metadata — sector / name info (best-effort; may return EMPTY_METADATA)
+    """
+
+    @abstractmethod
+    def get_prices(self, assets=None) -> pd.DataFrame:
+        """Return a DataFrame of adjusted close prices.
+
+        Args:
+            assets: ticker string, list of tickers, or None for all available.
+
+        Returns:
+            DataFrame with DatetimeIndex (rows = trading days) and ticker
+            columns.  Callers are responsible for slicing to their date range.
+        """
+
+    @abstractmethod
+    def get_returns(
+        self,
+        start_date,
+        end_date,
+        stocks=None,
+        outlier_return: float = 10,
+    ) -> pd.DataFrame:
+        """Return gross-return ratios for *stocks* over [start_date, end_date].
+
+        Args:
+            start_date: inclusive start (datetime or date).
+            end_date:   inclusive end   (datetime or date).
+            stocks:     list of tickers to include; None / [] = all available.
+            outlier_return: rows where any return exceeds this ratio are
+                            dropped (default 10 = 900 % gain in one day).
+
+        Returns:
+            DataFrame with DatetimeIndex and ticker columns.  Any ticker that
+            has NaN in the window is dropped entirely.
+        """
+
+    @abstractmethod
+    def get_metadata(self, asset: str) -> dict:
+        """Return a metadata dict for *asset*.
+
+        Keys: name, sector, subsector, market_cap.
+        Implementations that cannot provide a field return EMPTY_METADATA
+        values (empty string / 0) rather than raising.
+        """

--- a/source/data/base.py
+++ b/source/data/base.py
@@ -5,6 +5,7 @@ throughout the codebase (backtest.py, account_manager.py, run_daily.py).
 FakeDataManager in tests/ also subclasses this so type-checking catches drift.
 """
 from abc import ABC, abstractmethod
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -35,8 +36,9 @@ class DataManagerBase(ABC):
     run_daily.py.  The FakeDataManager in tests/ satisfies the same interface
     so unit tests remain hermetic.
 
-    get_prices  — full price history for the requested tickers
+    get_prices  — full price history for the requested tickers (abstract)
     get_returns — gross-return ratios for a date window, outliers removed
+                  (concrete: implemented here in terms of get_prices)
     get_metadata — sector / name info (best-effort; may return EMPTY_METADATA)
     """
 
@@ -52,20 +54,23 @@ class DataManagerBase(ABC):
             columns.  Callers are responsible for slicing to their date range.
         """
 
-    @abstractmethod
     def get_returns(
         self,
         start_date,
         end_date,
-        stocks=None,
+        stocks: Optional[List[str]] = None,
         outlier_return: float = 10,
     ) -> pd.DataFrame:
         """Return gross-return ratios for *stocks* over [start_date, end_date].
 
+        Implemented once here and shared by all providers: fetch prices via
+        get_prices(), slice to the date window, drop tickers with any NaN,
+        compute quotient_diff, and drop rows exceeding *outlier_return*.
+
         Args:
             start_date: inclusive start (datetime or date).
             end_date:   inclusive end   (datetime or date).
-            stocks:     list of tickers to include; None / [] = all available.
+            stocks:     list of tickers; None / [] = all available.
             outlier_return: rows where any return exceeds this ratio are
                             dropped (default 10 = 900 % gain in one day).
 
@@ -73,6 +78,23 @@ class DataManagerBase(ABC):
             DataFrame with DatetimeIndex and ticker columns.  Any ticker that
             has NaN in the window is dropped entirely.
         """
+        assets = stocks if stocks else None
+        prices = self.get_prices(assets)
+
+        if prices.empty:
+            return pd.DataFrame()
+
+        start_ts = pd.Timestamp(start_date)
+        end_ts = pd.Timestamp(end_date)
+        prices = prices[(prices.index >= start_ts) & (prices.index <= end_ts)]
+        prices = prices.dropna(axis=0, how="all").dropna(axis=1)
+
+        if len(prices) < 2:
+            return pd.DataFrame()
+
+        returns = prices.apply(quotient_diff, axis=0)
+        returns = returns[returns < outlier_return].dropna(axis=0)
+        return returns
 
     @abstractmethod
     def get_metadata(self, asset: str) -> dict:

--- a/source/data/local.py
+++ b/source/data/local.py
@@ -37,7 +37,6 @@ class LocalDataManager(DataManagerBase):
         self.metadata = get_tickers_metadata(metadata_file)
         self.db_file = db_file
         self.metadata_file = metadata_file
-        self._returns_cache: dict = {}
 
     def get_prices(self, assets=None) -> pd.DataFrame:
         if assets is None or (hasattr(assets, '__len__') and len(assets) == 0):
@@ -60,40 +59,6 @@ class LocalDataManager(DataManagerBase):
         out = pd.DataFrame(index=self.db.index, columns=assets)
         out.update(self.db)
         return out
-
-    def get_returns(
-        self,
-        start_date,
-        end_date,
-        stocks=None,
-        outlier_return: float = 10,
-    ) -> pd.DataFrame:
-        stocks = stocks or []
-        cache_key = (start_date, end_date)
-        if not stocks and cache_key in self._returns_cache:
-            return self._returns_cache[cache_key]
-
-        for s in stocks:
-            if s not in self.db.columns:
-                try:
-                    self.get_prices(s)
-                except Exception:
-                    log.warning("Failed to obtain data for %s", s)
-
-        db = self.db[
-            (self.db.index >= pd.Timestamp(start_date)) &
-            (self.db.index <= pd.Timestamp(end_date))
-        ]
-        db = db.dropna(axis=0, how="all").dropna(axis=1)
-        if len(db) < 2:
-            return pd.DataFrame()
-
-        db_r = db.apply(quotient_diff, axis=0)
-        db_r = db_r[db_r < outlier_return].dropna(axis=0)
-
-        if not stocks:
-            self._returns_cache[cache_key] = db_r
-        return db_r
 
     def get_metadata(self, asset: str) -> dict:
         import yfinance as yf

--- a/source/data/local.py
+++ b/source/data/local.py
@@ -1,0 +1,115 @@
+"""LocalDataManager — pickle-file backed data provider.
+
+This is the original DataManager from database_handler.py, promoted to a
+first-class implementation of DataManagerBase.  It exists to support the
+manual / interactive workflow (Jupyter notebooks, ad-hoc rebalancing) where
+the price database is a local close.pkl file kept up-to-date by
+database_handler.update_database().
+
+For the automated daily job use AlpacaDataManager instead.
+"""
+import logging
+
+import pandas as pd
+
+from data.base import DataManagerBase, EMPTY_METADATA, quotient_diff
+
+log = logging.getLogger(__name__)
+
+
+class LocalDataManager(DataManagerBase):
+    """Read prices and metadata from local pickle files.
+
+    Args:
+        db_file:       path (str or Path) to the close-price pickle, e.g.
+                       "data/close.pkl".
+        metadata_file: path to the metadata pickle, e.g. "data/metadata.pkl".
+
+    The pickle files are loaded once at construction time.  Call
+    database_handler.update_database() separately to refresh them.
+    """
+
+    def __init__(self, db_file="close.pkl", metadata_file="metadata.pkl"):
+        # Import here to avoid a circular dependency: database_handler imports
+        # LocalDataManager, so we defer the heavy imports to call time.
+        from database_handler import load_database, get_tickers_metadata
+        self.db = load_database(db_file)
+        self.metadata = get_tickers_metadata(metadata_file)
+        self.db_file = db_file
+        self.metadata_file = metadata_file
+        self._returns_cache: dict = {}
+
+    def get_prices(self, assets=None) -> pd.DataFrame:
+        if assets is None or (hasattr(assets, '__len__') and len(assets) == 0):
+            return self.db
+
+        if isinstance(assets, str):
+            assets = [assets]
+
+        missing = [a for a in assets if a not in self.db.columns]
+        if missing:
+            from database_handler import update_database_single_stock
+            for asset in missing:
+                try:
+                    self.db = update_database_single_stock(
+                        self.db, asset, self.db_file, self.metadata_file
+                    )
+                except Exception:
+                    log.warning("Could not fetch prices for %s", asset)
+
+        out = pd.DataFrame(index=self.db.index, columns=assets)
+        out.update(self.db)
+        return out
+
+    def get_returns(
+        self,
+        start_date,
+        end_date,
+        stocks=None,
+        outlier_return: float = 10,
+    ) -> pd.DataFrame:
+        stocks = stocks or []
+        cache_key = (start_date, end_date)
+        if not stocks and cache_key in self._returns_cache:
+            return self._returns_cache[cache_key]
+
+        for s in stocks:
+            if s not in self.db.columns:
+                try:
+                    self.get_prices(s)
+                except Exception:
+                    log.warning("Failed to obtain data for %s", s)
+
+        db = self.db[
+            (self.db.index >= pd.Timestamp(start_date)) &
+            (self.db.index <= pd.Timestamp(end_date))
+        ]
+        db = db.dropna(axis=0, how="all").dropna(axis=1)
+        if len(db) < 2:
+            return pd.DataFrame()
+
+        db_r = db.apply(quotient_diff, axis=0)
+        db_r = db_r[db_r < outlier_return].dropna(axis=0)
+
+        if not stocks:
+            self._returns_cache[cache_key] = db_r
+        return db_r
+
+    def get_metadata(self, asset: str) -> dict:
+        import yfinance as yf
+        from database_handler import save_metadata
+        assert isinstance(asset, str)
+        if asset in self.metadata:
+            return self.metadata[asset]
+        try:
+            info = yf.Ticker(asset).info
+            meta = EMPTY_METADATA.copy()
+            meta["name"] = info.get("shortName", asset)
+            meta["sector"] = info.get("sector", "")
+            meta["subsector"] = info.get("industry", "")
+            meta["market_cap"] = info.get("marketCap", 0)
+            self.metadata[asset] = meta
+            save_metadata(self.metadata, self.metadata_file)
+        except Exception:
+            self.metadata[asset] = {**EMPTY_METADATA, "name": asset}
+        return self.metadata[asset]

--- a/source/database_handler.py
+++ b/source/database_handler.py
@@ -110,8 +110,9 @@ class DataManager:
         """
         Computes returns from specific dates and list of securities.
         """
-        if len(stocks) == 0 and hasattr(self, "_returns"):
-            return self._returns
+        cache_key = (start_date, end_date)
+        if len(stocks) == 0 and hasattr(self, "_returns_cache") and cache_key in self._returns_cache:
+            return self._returns_cache[cache_key]
 
         for s in stocks:
             if s not in self.db.columns:
@@ -127,7 +128,10 @@ class DataManager:
         db_r = db.apply(quotien_diff, axis=0)  # compute returns
         db_r = db_r[db_r < outlier_return].dropna(axis=0)  # Filter outliers
 
-        self._returns = db_r
+        if len(stocks) == 0:
+            if not hasattr(self, "_returns_cache"):
+                self._returns_cache = {}
+            self._returns_cache[cache_key] = db_r
         return db_r
 
     def repair_data(self, stock_symbol, start_date):

--- a/source/database_handler.py
+++ b/source/database_handler.py
@@ -216,14 +216,14 @@ def get_market_cap(ticker_str):
 
 def get_sp500_tickers():
     path_to_file = Path(os.path.join(path_to_data, "sp500.pkl"))
-    if not path_to_file.exists:
+    if not path_to_file.exists():
         save_sp500_tickers()
     return pickle.load(path_to_file.open("rb"))
 
 
 def get_tickers_metadata(meta_data_file):
     path_to_file = Path(os.path.join(path_to_data, meta_data_file))
-    if not path_to_file.exists:
+    if not path_to_file.exists():
         return {}
     return pickle.load(path_to_file.open("rb"))
 

--- a/source/database_handler.py
+++ b/source/database_handler.py
@@ -30,13 +30,7 @@ parent_path = os.path.abspath(os.path.join(path_to_file, os.pardir))
 sys.path.insert(0, parent_path)
 path_to_data = os.path.abspath(os.path.join(parent_path, "data"))
 from source import util
-
-EMPTY_METADATA = {
-    "name": "",
-    "sector": "",
-    "subsector": "",
-    "market_cap": "",
-}
+from data.base import EMPTY_METADATA, quotient_diff as quotien_diff  # noqa: F401
 
 
 def set_data_path(new_path_to_data):
@@ -54,119 +48,9 @@ def set_data_path(new_path_to_data):
     return path_is_new
 
 
-class DataManager:
-    """
-    An instance of this class access and maintains the data.
-    """
-
-    def __init__(self, db_file="close.pkl", metadata_file="metadata.pkl"):
-        self.db = load_database(db_file)
-        self.metadata = get_tickers_metadata(metadata_file)
-        self.db_file = db_file
-        self.metadata_file = metadata_file
-
-    def get_prices(self, assets=None):
-        """
-        assets (str or list): an asset or list of assets.
-        """
-        if assets is None or len(assets) == 0:
-            return self.db
-
-        if type(assets) == str:
-            assets = [assets]
-
-        for asset in assets:
-            if asset not in self.db.columns:
-                self.db = update_database_single_stock(
-                    self.db, asset, self.db_file, self.metadata_file
-                )
-        df_out = pd.DataFrame(index=self.db.index, columns=assets)
-        df_out.update(self.db)
-        return df_out
-
-    def get_metadata(self, asset):
-        assert type(asset) == str
-        if asset in self.metadata:
-            return self.metadata[asset]
-        try:
-            asset_ticket = yf.Ticker(asset)
-            info = asset_ticket.info
-            self.metadata[asset] = EMPTY_METADATA.copy()
-            self.metadata[asset]["name"] = info["shortName"]
-            self.metadata[asset]["quoteType"] = info["quoteType"]
-            if info["quoteType"] == "ETF":
-                self.metadata[asset]["sector"] = "ETF"
-                self.metadata[asset]["industry"] = "ETF"
-            elif info["quoteType"] == "EQUITY":
-                self.metadata[asset]["sector"] = info["sector"]
-                self.metadata[asset]["industry"] = info["industry"]
-        except Exception:
-            self.metadata[asset] = EMPTY_METADATA
-            self.metadata[asset]["name"] = asset
-        save_metadata(self.metadata, self.metadata_file)
-        return self.metadata[asset]
-
-    def get_returns(self, start_date, end_date, stocks=[], outlier_return=10):
-        """
-        Computes returns from specific dates and list of securities.
-        """
-        cache_key = (start_date, end_date)
-        if len(stocks) == 0 and hasattr(self, "_returns_cache") and cache_key in self._returns_cache:
-            return self._returns_cache[cache_key]
-
-        for s in stocks:
-            if s not in self.db.columns:
-                try:
-                    self.get_prices(s)
-                    self.get_metadata(s)
-                except Exception:
-                    print(f"Fail while obtaining data from security {s}")
-        db = self.db[self.db.index >= start_date]
-        db = db[db.index <= end_date]
-        db = db.dropna(axis=0, how="all")
-        db = db.dropna(axis=1)
-        db_r = db.apply(quotien_diff, axis=0)  # compute returns
-        db_r = db_r[db_r < outlier_return].dropna(axis=0)  # Filter outliers
-
-        if len(stocks) == 0:
-            if not hasattr(self, "_returns_cache"):
-                self._returns_cache = {}
-            self._returns_cache[cache_key] = db_r
-        return db_r
-
-    def repair_data(self, stock_symbol, start_date):
-        if stock_symbol not in self.db.columns:
-            return
-        stock = yf.Ticker(stock_symbol)
-        trials = 3
-        for repairing_date in reversed(self.db.index):
-            if repairing_date < start_date:
-                break
-            if np.isnan(self.db.loc[repairing_date, stock_symbol]):
-                time.sleep(np.random.uniform(0, 0.1))
-                update = stock.history(
-                    start=repairing_date,
-                    end=repairing_date + dt.timedelta(days=1),
-                ).Close
-                if (
-                    repairing_date in update.index
-                    and update.loc[repairing_date] != np.nan
-                ):
-                    self.db.loc[repairing_date, stock_symbol] = update.loc[
-                        repairing_date
-                    ]
-                else:
-                    print("Not repaired", stock_symbol, repairing_date)
-                    trials -= 1
-                    if trials == 0:
-                        print("Still nan")
-                        break
-
-        save_database(self.db, self.db_file)
-
-    @property
-    def securities(self):
-        return list(self.db.columns)
+# DataManager is the backward-compatible alias for the local pickle workflow.
+# New code should import from data.local or data.alpaca directly.
+from data.local import LocalDataManager as DataManager  # noqa: F401
 
 
 def save_sp500_tickers():
@@ -349,15 +233,7 @@ def add_stock(db, stock_symbol, start=None, end=None):
         return db, False
 
 
-def quotien_diff(x):
-    """
-    Computes a division diff operation. Used to compute
-    return out of stock prices.
-    Args:
-        x (DataSeries): pandas data series
-    """
-    y = np.array(x)
-    return pd.Series(y[1:] / y[:-1], index=x[1:].index)
+# quotien_diff is now imported from data.base as an alias above.
 
 
 def get_returns(

--- a/source/market_hours.py
+++ b/source/market_hours.py
@@ -1,0 +1,98 @@
+"""NYSE trading calendar and idempotency utilities for the daily job.
+
+is_trading_day  — returns True if date is a NYSE business day
+IdempotencyGuard — file-based marker that prevents duplicate runs
+"""
+import datetime as dt
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+try:
+    import pandas_market_calendars as mcal
+    _NYSE = mcal.get_calendar("NYSE")
+    _HAS_MARKET_CAL = True
+except ImportError:
+    _HAS_MARKET_CAL = False
+    log.warning(
+        "pandas_market_calendars not installed; "
+        "market-open check falls back to weekday-only (Mon–Fri)."
+    )
+
+
+def is_trading_day(date: dt.date = None) -> bool:
+    """Return True if *date* is a NYSE trading day (not a holiday, not a weekend).
+
+    Falls back to weekday check when pandas_market_calendars is absent.
+    """
+    if date is None:
+        date = dt.date.today()
+    if isinstance(date, dt.datetime):
+        date = date.date()
+
+    if _HAS_MARKET_CAL:
+        schedule = _NYSE.schedule(
+            start_date=date.isoformat(), end_date=date.isoformat()
+        )
+        return not schedule.empty
+
+    return date.weekday() < 5  # Mon=0 … Fri=4
+
+
+class IdempotencyGuard:
+    """Prevents the daily job from running more than once per calendar day.
+
+    Workflow:
+        guard = IdempotencyGuard(Path("run_state"))
+        if guard.already_ran():
+            sys.exit(0)
+        if not guard.acquire_lock():
+            sys.exit(1)          # another process is running
+        try:
+            ... do work ...
+            guard.mark_success()
+        finally:
+            guard.release_lock()
+
+    Files created under *run_dir*:
+        job.lock          — PID of the running process; deleted on release
+        success_YYYY-MM-DD — empty marker; presence means today ran OK
+    """
+
+    def __init__(self, run_dir: Path):
+        self._run_dir = Path(run_dir)
+        self._run_dir.mkdir(parents=True, exist_ok=True)
+        self._lock_file = self._run_dir / "job.lock"
+
+    def _success_path(self, date: dt.date) -> Path:
+        return self._run_dir / f"success_{date.isoformat()}"
+
+    def already_ran(self, date: dt.date = None) -> bool:
+        """Return True if today's success marker already exists."""
+        if date is None:
+            date = dt.date.today()
+        return self._success_path(date).exists()
+
+    def acquire_lock(self) -> bool:
+        """Write a PID lock file.  Returns False if the lock is held by another process."""
+        if self._lock_file.exists():
+            existing_pid = self._lock_file.read_text().strip()
+            log.warning("Lock file exists (PID %s). Another run may be active.", existing_pid)
+            return False
+        self._lock_file.write_text(str(os.getpid()))
+        return True
+
+    def release_lock(self):
+        """Remove the PID lock file."""
+        try:
+            self._lock_file.unlink()
+        except FileNotFoundError:
+            pass
+
+    def mark_success(self, date: dt.date = None):
+        """Write the success marker for *date* (default: today)."""
+        if date is None:
+            date = dt.date.today()
+        self._success_path(date).touch()

--- a/source/opt_tools.py
+++ b/source/opt_tools.py
@@ -1,25 +1,102 @@
+"""Portfolio optimisation via a mean–CVaR mixed-integer programme.
+
+Mathematical formulation
+------------------------
+Given *n* historical scenarios and *m* assets, let:
+
+    r_{ij}  gross return (price ratio) of asset j in scenario i,
+              r_{ij} = price_{j,t+1} / price_{j,t}  (> 0)
+    r̄_j     sample mean gross return: r̄_j = (1/n) Σ_i r_{ij}
+    p_j     current price of asset j
+    B       total portfolio budget = current equity + available cash
+    α ∈ (0,1)  CVaR confidence level (e.g. 0.90 → worst 10 % of scenarios)
+    β ∈ [0,1]  convex weight on expected return vs CVaR (see CvarParameters)
+
+Decision variables:
+
+    x_j ≥ 0       shares held in asset j  (continuous, or integer when
+                   fractional=False and the position is not already fractional)
+    cash ≥ 0      uninvested cash; earns 0 net return
+    η ∈ ℝ         Value at Risk threshold (negative when portfolio typically gains)
+    z_i ≥ 0       per-scenario shortfall above η  (CVaR auxiliary)
+
+Portfolio gross return in scenario i:
+
+    ρ_i = ( Σ_j r_{ij} · p_j · x_j  +  cash ) / B
+
+Portfolio gross loss in scenario i  (negative of gross return):
+
+    L_i = −ρ_i = −Σ_j r_{ij} · p_j · x_j / B  −  cash / B
+
+The CVaR at level α is expressed via the Rockafellar–Uryasev (2000)
+linearisation:
+
+    CVaR_α(L) = min_η { η + 1 / [n(1−α)] · Σ_i (L_i − η)⁺ }
+
+Substituting z_i ≥ L_i − η, z_i ≥ 0:
+
+    CVaR = η + 1 / [n(1−α)] · Σ_i z_i
+
+Full programme
+~~~~~~~~~~~~~~
+    max   β · Σ_j r̄_j · p_j · x_j / B
+        − (1−β) · [ η + 1/(n(1−α)) · Σ_i z_i ]            (P)
+
+    s.t.  Σ_j p_j · x_j + cash = B                         budget
+          z_i ≥ −Σ_j r_{ij} · p_j · x_j / B
+                − cash / B − η        ∀ i                   CVaR linearisation
+          z_i ≥ 0                     ∀ i
+          η  ∈ ℝ
+          cash ∈ [0, B]
+          x_j ∈ [0, B/p_j]  or  ℤ≥0  (per asset)
+
+Optional turnover constraint (active when portfolio_delta is finite):
+
+    Let pos_j = current shares held in asset j.
+    Introduce δ_j ≥ 0 with δ_j ≥ pos_j − x_j  (sell amount for asset j).
+    Then: Σ_j δ_j ≤ Δ  limits total shares reduced across the portfolio.
+
+Objective interpretation
+~~~~~~~~~~~~~~~~~~~~~~~~
+    β = 0   → pure CVaR minimisation (most conservative)
+    β = 1   → maximise expected gross return (ignores risk)
+    β = 0.95 (default) → high weight on return, CVaR acts as a soft penalty
+
+Reported statistics
+~~~~~~~~~~~~~~~~~~~
+    VaR  = −η              (positive when the α-quantile loss is a gain)
+    CVaR = −CVaR_value     (positive value = expected gross loss in worst scenarios)
+    mean = r̄ · w           (expected portfolio gross return; w = allocation weights)
+    std  = √(w᷊ Σ w)        (portfolio gross-return standard deviation)
+
+References
+----------
+Rockafellar, R.T. & Uryasev, S. (2000). Optimization of Conditional
+Value-at-Risk. Journal of Risk, 2(3), 21–41.
 """
-Created on Thu May 23 22:35:42 2019
 
-@author: dduque
-
-Implements several optimization models for
-portfolio optimization.
-"""
-
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
 from ortools.linear_solver import pywraplp
 
+log = logging.getLogger(__name__)
+
+# Solver status codes returned by OR-Tools CBC.
+_STATUS_NAMES = {
+    pywraplp.Solver.OPTIMAL:    "OPTIMAL",
+    pywraplp.Solver.FEASIBLE:   "FEASIBLE",
+    pywraplp.Solver.INFEASIBLE: "INFEASIBLE",
+    pywraplp.Solver.ABNORMAL:   "ABNORMAL",
+    pywraplp.Solver.NOT_SOLVED: "NOT_SOLVED",
+}
+
 
 class AbstractModel(ABC):
-    """
-    Abstract representation of an asset allocation model
-    Attributes:
-        m (object): a reference of a model that performs the optimization.
-    """
+    """Abstract representation of an asset-allocation optimisation model."""
 
     @abstractmethod
     def __init__(self):
@@ -32,70 +109,85 @@ class AbstractModel(ABC):
 
 @dataclass
 class CvarParameters:
-    # CVaR level at risk. Fractile at risk. If L denotes the loss, 1-cvar_alpha
-    # is the probability of having a L that exceeds the value at risk VaR(-L).
-    # Typically this value is close to 1.
+    """Parameters controlling the mean–CVaR objective (P).
+
+    Attributes:
+        alpha: CVaR confidence level α ∈ (0, 1).  The CVaR is computed over
+               the worst (1−α) fraction of scenarios.  Typical value: 0.90
+               (CVaR covers the worst 10 % of return scenarios).
+        beta:  Convex weight β ∈ [0, 1] on the expected-return term of (P).
+               β = 0 → minimise CVaR only; β = 1 → maximise expected return
+               only; β = 0.95 (default) → strong return focus with CVaR
+               penalty.
+    """
     alpha: float
-    # Value for the convex combination between expected value and CVaR. If
-    # beta = 0, this yields a CVaR minimization model.
     beta: float
 
+
 def default_cvar_parameters() -> CvarParameters:
+    """Return α = 0.90, β = 0.95 (return-focused with tail-risk penalty)."""
     return CvarParameters(alpha=0.90, beta=0.95)
 
 
 class cvar_model_ortools(AbstractModel):
+    """Mean–CVaR MIP solved with OR-Tools CBC.
+
+    Builds the programme (P) described in the module docstring and exposes
+    ``change_cvar_params`` to re-solve under different α / β without
+    rebuilding the constraint matrix.
+
+    Args:
+        cvar_params:       CVaR confidence level and objective weight.
+        r:                 (n × m) ndarray of gross returns (price ratios).
+                           Rows are scenarios; columns are assets in the same
+                           order as *price*.
+        price:             pd.Series indexed by ticker with current prices.
+        budget:            Available cash to invest on top of the current
+                           portfolio equity (i.e. account.cash_onhand).
+        current_portfolio: Existing Portfolio whose positions seed the budget
+                           calculation.  Pass None to build from scratch.
+        portfolio_delta:   Maximum total shares that may be reduced across
+                           all current positions (turnover limit Δ).
+                           0 = no sells allowed; large value = unconstrained.
+        fractional:        Allow fractional share quantities.  When False,
+                           x_j is integer unless the existing position is
+                           already fractional.
+        ignore:            Tickers excluded from the optimisation (forced to
+                           retain their current position at most).
+        must_buy:          Dict mapping ticker → minimum shares that must be
+                           held in the solution.
+        time_limit_ms:     Wall-clock time limit for the CBC solver in
+                           milliseconds.  Raises RuntimeError if the limit is
+                           reached without a feasible solution.  Default 30 s.
+    """
+
     def __init__(
         self,
-        cvar_params,
-        r,
-        price,
-        budget,
+        cvar_params: CvarParameters,
+        r: np.ndarray,
+        price: pd.Series,
+        budget: float,
         current_portfolio=None,
-        portfolio_delta=0,
-        fractional=True,
-        ignore=[],
-        must_buy={},
+        portfolio_delta: float = 0,
+        fractional: bool = True,
+        ignore: list = [],
+        must_buy: dict = {},
+        time_limit_ms: int = 30_000,
     ):
-        """
-        Expectation/CVaR model (using OR-tools)
-        Let x be the number of stock to purchase, at price p.
-        E detones the expectation symbol and CVaR is computed
-        at level cvar_alpha (>0.5).
-        max beta E[sum_j r_j*p_j*x_j ] - (1-beta) CVaR(L)
-            s.t.
-            L = - sum_j r_j*p_j*x_j #The loss
-            sum_j p_j*x_j <= budget
-
-        Args:
-            cvar_params (CvarParameters): CVaR parameters used to build the
-                model.
-            r (ndarray): returns data, where each column has the returns
-                of a particular stock.
-            price (DataFrame): price per stock.
-            budget (float): total amount to be invested.
-            current_portfolio (Portfolio): The current porfolio to revalance.
-                If None, a new portfolio is created form scratch.
-            portfolio_delta (float): number of shares by which the new
-                portfolio can differ from the `current_portfolio`.
-            fraction (bool): optional - if true (default), the portfolio is
-                allow to have fractional number of stocks.
-            ignore (list(str)): list of tickers to ignore in the optimization.
-            must_buy (dict): A dictionary with tickers and the number of shares
-                that must be bought from each ticker.
-        """
-        # CVaR paramters
         cvar_alpha = cvar_params.alpha
         assert cvar_alpha < 1.0, "CVaR alpha must be less than 1."
         cvar_beta = cvar_params.beta
-        # Data prep
-        assert len(r) > 0 and len(r[0]) == len(
-            price
-        ), "The number of securities in the returns array must match that in the price array"
+
+        assert len(r) > 0 and len(r[0]) == len(price), (
+            "Columns of r must match entries of price "
+            f"(got {len(r[0])} vs {len(price)})."
+        )
+
         self.r_bar = np.mean(r, axis=0)
         self.cov = np.cov(r, rowvar=False)
-        n = len(r)  # Number of returns
+        n = len(r)          # number of scenarios
         stocks = price.index.to_list()
+
         portfolio_value = (
             0
             if current_portfolio is None
@@ -104,80 +196,76 @@ class cvar_model_ortools(AbstractModel):
                 for s in current_portfolio.assets
             )
         )
-        new_portfolio_value = portfolio_value + budget
-        solver = pywraplp.Solver.CreateSolver("CBC")
+        B = portfolio_value + budget   # total budget
 
-        # Number of shares to buy from each stock
+        solver = pywraplp.Solver.CreateSolver("CBC")
+        solver.set_time_limit(time_limit_ms)
+
+        # ── Decision variables ────────────────────────────────────────────
+
+        # x_j: shares held in each asset (continuous or integer per asset)
         x = {}
         for s in stocks:
             x_lb = 0 if s not in must_buy else must_buy[s]
             x_ub = (
-                new_portfolio_value / price[s]
+                B / price[s]
                 if (s not in ignore and price[s] > 0)
                 else np.maximum(0.0, current_portfolio.get_position(s))
             )
             if fractional or current_portfolio.position_is_fractional(s):
-                x[s] = solver.NumVar(x_lb, x_ub, f"x{s}")
+                x[s] = solver.NumVar(x_lb, x_ub, f"x_{s}")
             else:
-                x[s] = solver.IntVar(x_lb, x_ub, f"x{s}")
+                x[s] = solver.IntVar(x_lb, x_ub, f"x_{s}")
 
-        # Auxiliary variable to compute shortfall in cvar
-        z = {}
-        for j in range(n):
-            z[j] = solver.NumVar(0.0, solver.infinity(), f"z{j}")
+        # z_i: per-scenario shortfall above VaR threshold η
+        z = {i: solver.NumVar(0.0, solver.infinity(), f"z_{i}") for i in range(n)}
 
-        # Value at risk
+        # η: Value at Risk threshold (unbounded; can be negative)
         eta = solver.NumVar(-solver.infinity(), solver.infinity(), "eta")
 
-        # Cash
-        cash = solver.NumVar(0, new_portfolio_value, "cash")
+        # cash: uninvested portion of budget
+        cash = solver.NumVar(0, B, "cash")
 
-        # Portfolio budget contraint
-        solver.Add(
-            sum(price[s] * x[s] for s in stocks) + cash == new_portfolio_value
-        )
+        # ── Constraints ───────────────────────────────────────────────────
 
-        # CVaR computation, used in the objective function.
-        cvar = eta + (1.0 / (n * (1 - cvar_alpha))) * sum(
-            z[i] for i in range(n)
-        )
+        # Budget: Σ p_j x_j + cash = B
+        solver.Add(sum(price[s] * x[s] for s in stocks) + cash == B)
 
-        # CVaR linearlization
+        # CVaR linearisation: z_i ≥ L_i − η  where  L_i = −ρ_i
         for i in range(n):
             solver.Add(
                 z[i]
                 >= sum(
-                    (
-                        -(r[i, j]) * price[s] * x[s] / new_portfolio_value
-                        for (j, s) in enumerate(stocks)
-                    )
+                    -r[i, j] * price[s] * x[s] / B
+                    for (j, s) in enumerate(stocks)
                 )
-                - cash / new_portfolio_value
+                - cash / B
                 - eta
             )
 
-        # Limit number of rebalancing sell transactions
+        # Turnover limit: total shares reduced ≤ portfolio_delta
         if current_portfolio is not None:
             delta_x = {}
             for s in current_portfolio.assets:
-                position_s = current_portfolio.get_position(s)
-                delta_x[s] = solver.NumVar(0.0, position_s, f"delta_x{s}")
-                # solver.Add(x[s] - position_s <= delta_x[s])  # Buy
-                solver.Add(position_s - x[s] <= delta_x[s])  # Sell
+                pos_s = current_portfolio.get_position(s)
+                delta_x[s] = solver.NumVar(0.0, pos_s, f"delta_{s}")
+                solver.Add(pos_s - x[s] <= delta_x[s])
             solver.Add(
                 sum(delta_x[s] for s in current_portfolio.assets)
                 <= portfolio_delta
             )
 
-        # Objective function
+        # ── Objective: max β·E[ρ] − (1−β)·CVaR_α(L) ─────────────────────
+        cvar_expr = eta + (1.0 / (n * (1 - cvar_alpha))) * sum(z[i] for i in range(n))
         exp_return = sum(
-            self.r_bar[j] * price[s] * x[s] / new_portfolio_value
+            self.r_bar[j] * price[s] * x[s] / B
             for (j, s) in enumerate(stocks)
         )
-        solver.Maximize(cvar_beta * exp_return - (1 - cvar_beta) * cvar)
+        solver.Maximize(cvar_beta * exp_return - (1 - cvar_beta) * cvar_expr)
 
+        # ── Persist references for optimize() and change_cvar_params() ────
         self.solver = solver
-        self.cvar = cvar
+        self.cvar = cvar_expr
         self.exp_return = exp_return
         self.cash = cash
         self.x = x
@@ -188,63 +276,119 @@ class cvar_model_ortools(AbstractModel):
         self.stocks = stocks
         self.price = price
         self.n = n
+        self.B = B
+        self._time_limit_ms = time_limit_ms
 
-    def optimize(self, mip_gap=0.0001):
-        solver_parameters = pywraplp.MPSolverParameters()
-        solver_parameters.SetDoubleParam(
-            solver_parameters.RELATIVE_MIP_GAP, mip_gap
+    def optimize(self, mip_gap: float = 0.0001) -> tuple:
+        """Solve (P) and return the portfolio DataFrame plus statistics.
+
+        Args:
+            mip_gap: Relative MIP optimality gap tolerance.  The solver
+                     stops when the gap between the best integer solution
+                     and the LP relaxation bound falls below this value.
+                     Default 0.01 % (tight; increase to ~0.01 to trade
+                     optimality for speed on large universes).
+
+        Returns:
+            sol_out: pd.DataFrame indexed by ticker with columns
+                     price, qty, position (= price × qty), allocation
+                     (fraction of total equity), side ('buy').
+            stats:   dict with keys:
+                       mean   – expected portfolio gross return (scalar)
+                       std    – portfolio gross-return std dev (scalar)
+                       VaR    – Value at Risk = −η  (positive ≈ loss)
+                       CVaR   – CVaR of gross loss  (positive ≈ loss)
+                       status – solver status string (e.g. 'OPTIMAL')
+
+        Raises:
+            RuntimeError: if the solver returns INFEASIBLE, ABNORMAL, or
+                          NOT_SOLVED (including time-limit expiry without a
+                          feasible point).
+        """
+        params = pywraplp.MPSolverParameters()
+        params.SetDoubleParam(params.RELATIVE_MIP_GAP, mip_gap)
+
+        status = self.solver.Solve(params)
+        status_name = _STATUS_NAMES.get(status, str(status))
+
+        if status not in (pywraplp.Solver.OPTIMAL, pywraplp.Solver.FEASIBLE):
+            raise RuntimeError(
+                f"CVaR solver returned {status_name}. "
+                "Check that the returns matrix is non-degenerate and that "
+                "the budget is sufficient to buy at least one asset."
+            )
+
+        if status == pywraplp.Solver.FEASIBLE:
+            log.warning(
+                "CVaR solver reached time limit (%d ms) with a feasible but "
+                "possibly sub-optimal solution (gap may exceed %.4f).",
+                self._time_limit_ms, mip_gap,
+            )
+
+        log.debug(
+            "CVaR solver: status=%s  objective=%.6f  cash=%.2f  wall_time=%d ms",
+            status_name,
+            self.solver.Objective().Value(),
+            self.cash.solution_value(),
+            self.solver.wall_time(),
         )
-        self.solver.Solve(solver_parameters)
-        print("Objective func value:", self.solver.Objective().Value())
-        print("Cash on hand:", self.cash.solution_value())
+
         x_sol = np.round(
             np.array([self.x[s].solution_value() for s in self.stocks]), 6
         )
-        allocation = x_sol * self.price / np.sum(self.price * x_sol)
-        sol_out = pd.DataFrame(
-            {
-                "price": self.price,
-                "qty": x_sol,
-                "position": x_sol * self.price,
-                "allocation": allocation,
-                "side": "buy",
-            }
-        )
+        equity = x_sol * self.price
+        total_equity = equity.sum()
+        allocation = equity / total_equity if total_equity > 0 else equity * 0
 
-        stats = {}
-        stats["mean"] = self.r_bar.dot(allocation)
-        stats["std"] = np.sqrt(allocation.dot(self.cov.dot(allocation)))
-        stats["VaR"] = -self.eta.solution_value()
-        stats["CVaR"] = -self.cvar.solution_value()
+        sol_out = pd.DataFrame({
+            "price":      self.price,
+            "qty":        x_sol,
+            "position":   equity,
+            "allocation": allocation,
+            "side":       "buy",
+        })
 
+        stats = {
+            "mean":   float(self.r_bar.dot(allocation)),
+            "std":    float(np.sqrt(allocation.dot(self.cov.dot(allocation)))),
+            "VaR":    float(-self.eta.solution_value()),
+            "CVaR":   float(-self.cvar.solution_value()),
+            "status": status_name,
+        }
         return sol_out, stats
 
-    def change_cvar_params(self, cvar_beta=None, cvar_alpha=None):
-        self.cvar_beta = cvar_beta if cvar_beta is not None else self.cvar_beta
-        self.cvar_alpha = (
-            cvar_alpha if cvar_alpha is not None else self.cvar_alpha
-        )
-        print("Changing CVaR parameters:")
-        print("CVaR_beta: %5.3f" % (self.cvar_beta))
-        print("CVaR_alpha: %5.3f" % (self.cvar_alpha))
+    def change_cvar_params(
+        self,
+        cvar_beta: float = None,
+        cvar_alpha: float = None,
+    ) -> tuple:
+        """Update α and/or β, rebuild the objective, and re-solve.
 
+        Only the objective function is modified; the constraint matrix is
+        reused, so this is much cheaper than constructing a new model.
+
+        Args:
+            cvar_beta:  New β value (objective weight on expected return).
+            cvar_alpha: New α value (CVaR confidence level).  Triggers a
+                        rebuild of the CVaR expression inside the objective.
+
+        Returns:
+            Same (sol_out, stats) tuple as optimize().
+        """
+        if cvar_beta is not None:
+            self.cvar_beta = cvar_beta
         if cvar_alpha is not None:
+            self.cvar_alpha = cvar_alpha
             self.cvar = self.eta + (
                 1.0 / (self.n * (1 - self.cvar_alpha))
             ) * sum(self.z[i] for i in range(self.n))
-            self.solver.Maximize(
-                self.cvar_beta * self.exp_return
-                - (1 - self.cvar_beta) * self.cvar
-            )
-            self.m.objective = (
-                self.cvar_beta * self.exp_return
-                - (1 - self.cvar_beta) * self.cvar
-            )
 
-        if cvar_beta is not None:
-            self.solver.Maximize(
-                self.cvar_beta * self.exp_return
-                - (1 - self.cvar_beta) * self.cvar
-            )
-
+        log.debug(
+            "Updating CVaR params: alpha=%.3f  beta=%.3f",
+            self.cvar_alpha, self.cvar_beta,
+        )
+        self.solver.Maximize(
+            self.cvar_beta * self.exp_return
+            - (1 - self.cvar_beta) * self.cvar
+        )
         return self.optimize()

--- a/source/resources.py
+++ b/source/resources.py
@@ -8,6 +8,7 @@ import numpy as np
 import copy
 import pickle
 import math
+from dataclasses import dataclass
 from pathlib import Path
 from collections import defaultdict
 
@@ -120,13 +121,28 @@ class Order:
         self.qty = qty
         self.price = price
         self.operation_type = operation_type
-    
+
     def __str__(self):
         return f"{self.operation_type} {self.ticker} : {self.qty}" + \
             f" : {self.price:.4f}"
-    
+
     def __repr__(self):
         return self.__str__()
+
+
+@dataclass
+class Fill:
+    """Broker-confirmed execution of an order.
+
+    Unlike Order (which uses the optimizer's estimated price), Fill records
+    the actual price and time at which the broker executed the trade.
+    """
+    ticker: str
+    qty: float
+    fill_price: float
+    operation_type: str
+    fill_time: dt.datetime
+    broker_order_id: str
 
 
 class Account:
@@ -147,28 +163,28 @@ class Account:
         return self.portfolios[self.last_transaction]
     
     def deposit(self, deposit_date, amount):
-        self.cash_flow = self.cash_flow.append(
-            {
+        self.cash_flow = pd.concat(
+            [self.cash_flow, pd.DataFrame([{
                 "datetime": deposit_date,
                 "amount": amount,
                 "type": "deposit",
-            },
+            }])],
             ignore_index=True)
         self.cash_onhand = self.cash_onhand + amount
         return True
-    
+
     def withdraw(self, withdraw_date, amount):
         '''
         Withdraw money from cash onhand.
         '''
         if (self.cash_onhand < amount):
             return False
-        self.cash_flow = self.cash_flow.append(
-            {
+        self.cash_flow = pd.concat(
+            [self.cash_flow, pd.DataFrame([{
                 "datetime": withdraw_date,
                 "amount": amount,
                 "type": "withdraw",
-            },
+            }])],
             ignore_index=True)
         self.cash_onhand = self.cash_onhand - amount
         return True
@@ -188,22 +204,40 @@ class Account:
         if new_portfolio:
             self.last_transaction = transaction_date
             self.portfolios[transaction_date] = new_portfolio
+            rows = []
             for order in orders:
-                self.transactions = self.transactions.append(
-                    {
-                        "ticker": order.ticker,
-                        "datetime": transaction_date,
-                        "operation": order.operation_type,
-                        "qty": order.qty,
-                        "price": order.price,
-                    },
-                    ignore_index=True)
+                rows.append({
+                    "ticker": order.ticker,
+                    "datetime": transaction_date,
+                    "operation": order.operation_type,
+                    "qty": order.qty,
+                    "price": order.price,
+                })
                 if order.operation_type == OPERATION_BUY:
                     self.cash_onhand -= order.qty * order.price
                 elif order.operation_type == OPERATION_SELL:
                     self.cash_onhand += order.qty * order.price
+            if rows:
+                self.transactions = pd.concat(
+                    [self.transactions, pd.DataFrame(rows)], ignore_index=True)
             return True
         return False
+
+    def update_account_from_fills(self, transaction_date, fills):
+        '''
+        Updates the account using broker-confirmed fills rather than
+        optimizer-estimated prices. Uses the actual fill_price from each
+        Fill for cash accounting.
+
+        Args:
+            transaction_date (datetime): date of the transaction.
+            fills (list of Fill): broker-confirmed fills.
+        '''
+        orders = [
+            Order(f.ticker, f.qty, f.fill_price, f.operation_type)
+            for f in fills
+        ]
+        return self.update_account(transaction_date, orders)
     
     def operations_history(self):
         history = []
@@ -233,14 +267,14 @@ class Account:
         qty_delta = new_qty_with_split - new_qty
         self.cash_onhand += qty_delta * new_price
         operation_type = OPERATION_SPLIT if ratio > 1 else OPERATION_REVERSE_SPLIT
-        self.transactions = self.transactions.append(
-            {
+        self.transactions = pd.concat(
+            [self.transactions, pd.DataFrame([{
                 "ticker": asset,
                 "datetime": split_date,
                 "operation": operation_type,
                 "qty": new_qty_with_split,
                 "price": new_price,
-            },
+            }])],
             ignore_index=True)
         self.portfolios[split_date] = copy.deepcopy(self.portfolio)
         self.last_transaction = split_date

--- a/source/resources.py
+++ b/source/resources.py
@@ -294,10 +294,12 @@ def set_account_path(new_path_to_account):
     accounts_path = new_path_to_account
 
 
-def create_new_account(account_name, opening_date=dt.datetime.now):
+def create_new_account(account_name, opening_date=None):
     '''
     Creates a new account instance an saves it at `accounts_path/account_name`
     '''
+    if opening_date is None:
+        opening_date = dt.datetime.now()
     account = Account(account_name, opening_date)
     save_account(account)
     return account

--- a/source/resources.py
+++ b/source/resources.py
@@ -3,11 +3,13 @@ This module contains various data structures for data manipulation,
 optimization, and backtesting
 """
 import datetime as dt
+import os
 import pandas as pd
 import numpy as np
 import copy
 import pickle
 import math
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from collections import defaultdict
@@ -320,6 +322,44 @@ def save_account(account):
                 pickle.HIGHEST_PROTOCOL)
     path_account_class = path_to_account / 'AccountClass'
     pickle.dump(Account, path_account_class.open("wb"), pickle.HIGHEST_PROTOCOL)
+
+
+def save_account_atomic(account):
+    """Atomic variant of save_account: pickle to a temp file, then rename.
+
+    The rename is atomic on the same filesystem, so a crash mid-write never
+    leaves a corrupt .acc file referenced by index.txt.
+    """
+    backup_name = (
+        str(dt.datetime.now())
+        .replace(".", "").replace(":", "").replace(" ", "").replace("-", "")
+        + ".acc"
+    )
+    path_to_account = accounts_path / account.holder
+    if not path_to_account.exists():
+        path_to_account.mkdir(parents=True)
+
+    backup_file = path_to_account / backup_name
+    fd, tmp_path = tempfile.mkstemp(dir=path_to_account, suffix=".acc.tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            pickle.dump(account, f, pickle.HIGHEST_PROTOCOL)
+        os.replace(tmp_path, backup_file)  # atomic on same filesystem
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    index_file = path_to_account / "index.txt"
+    with open(index_file, "a") as writer:
+        writer.write(backup_name)
+
+    pickle.dump(Portfolio, (path_to_account / "PortfolioClass").open("wb"),
+                pickle.HIGHEST_PROTOCOL)
+    pickle.dump(Account, (path_to_account / "AccountClass").open("wb"),
+                pickle.HIGHEST_PROTOCOL)
 
 
 def load_account(account_name):

--- a/tests/fake.py
+++ b/tests/fake.py
@@ -1,0 +1,80 @@
+"""Fake data helpers for hermetic testing.
+
+FakeDataManager accepts a pre-built price DataFrame and implements the same
+interface as DataManager (get_prices, get_returns, get_metadata) without any
+disk I/O or network calls.  Import it in test modules that need price data.
+"""
+import numpy as np
+import pandas as pd
+
+
+def _quotient_diff(series):
+    """Same return computation as database_handler.quotien_diff."""
+    y = np.array(series)
+    return pd.Series(y[1:] / y[:-1], index=series.index[1:])
+
+
+class FakeDataManager:
+    """In-memory DataManager backed by a synthetic price DataFrame.
+
+    Args:
+        prices: DataFrame with tickers as columns and dates as index.
+                All prices must be positive floats.
+    """
+
+    def __init__(self, prices: pd.DataFrame):
+        self._prices = prices.copy()
+
+    def get_prices(self, assets=None) -> pd.DataFrame:
+        if assets is None:
+            return self._prices
+        if isinstance(assets, str):
+            assets = [assets]
+        cols = [a for a in assets if a in self._prices.columns]
+        return self._prices[cols]
+
+    def get_returns(
+        self, start_date, end_date, stocks=None, outlier_return=10
+    ) -> pd.DataFrame:
+        df = self._prices[
+            (self._prices.index >= pd.Timestamp(start_date))
+            & (self._prices.index <= pd.Timestamp(end_date))
+        ]
+        if stocks:
+            available = [s for s in stocks if s in df.columns]
+            df = df[available] if available else df
+        df = df.dropna(axis=1)
+        if len(df) < 2:
+            return pd.DataFrame()
+        db_r = df.apply(_quotient_diff, axis=0)
+        db_r = db_r[db_r < outlier_return].dropna(axis=0)
+        return db_r
+
+    def get_metadata(self, asset: str) -> dict:
+        return {
+            "name": asset,
+            "sector": "Unknown",
+            "subsector": "",
+            "market_cap": 0,
+        }
+
+
+def make_prices(
+    tickers,
+    n_days: int = 60,
+    start: str = "2023-01-02",
+    seed: int = 42,
+) -> pd.DataFrame:
+    """Create a deterministic price DataFrame for testing.
+
+    Uses a seeded random walk so results are reproducible.  The first ticker
+    gets a base price of 100, each subsequent one adds 20.
+    """
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range(start=start, periods=n_days)
+    prices = {}
+    for i, ticker in enumerate(tickers):
+        base = 100.0 + i * 20.0
+        daily_ret = rng.normal(0.0005, 0.015, n_days)
+        prices[ticker] = base * np.cumprod(1 + daily_ret)
+    return pd.DataFrame(prices, index=dates)

--- a/tests/fake.py
+++ b/tests/fake.py
@@ -1,21 +1,20 @@
 """Fake data helpers for hermetic testing.
 
 FakeDataManager accepts a pre-built price DataFrame and implements the same
-interface as DataManager (get_prices, get_returns, get_metadata) without any
-disk I/O or network calls.  Import it in test modules that need price data.
+interface as DataManagerBase without any disk I/O or network calls.
 """
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "source"))
+
 import numpy as np
 import pandas as pd
 
-
-def _quotient_diff(series):
-    """Same return computation as database_handler.quotien_diff."""
-    y = np.array(series)
-    return pd.Series(y[1:] / y[:-1], index=series.index[1:])
+from data.base import DataManagerBase, EMPTY_METADATA, quotient_diff
 
 
-class FakeDataManager:
-    """In-memory DataManager backed by a synthetic price DataFrame.
+class FakeDataManager(DataManagerBase):
+    """In-memory DataManagerBase backed by a synthetic price DataFrame.
 
     Args:
         prices: DataFrame with tickers as columns and dates as index.
@@ -46,17 +45,12 @@ class FakeDataManager:
         df = df.dropna(axis=1)
         if len(df) < 2:
             return pd.DataFrame()
-        db_r = df.apply(_quotient_diff, axis=0)
+        db_r = df.apply(quotient_diff, axis=0)
         db_r = db_r[db_r < outlier_return].dropna(axis=0)
         return db_r
 
     def get_metadata(self, asset: str) -> dict:
-        return {
-            "name": asset,
-            "sector": "Unknown",
-            "subsector": "",
-            "market_cap": 0,
-        }
+        return {**EMPTY_METADATA, "name": asset, "sector": "Unknown"}
 
 
 def make_prices(

--- a/tests/fake.py
+++ b/tests/fake.py
@@ -32,23 +32,6 @@ class FakeDataManager(DataManagerBase):
         cols = [a for a in assets if a in self._prices.columns]
         return self._prices[cols]
 
-    def get_returns(
-        self, start_date, end_date, stocks=None, outlier_return=10
-    ) -> pd.DataFrame:
-        df = self._prices[
-            (self._prices.index >= pd.Timestamp(start_date))
-            & (self._prices.index <= pd.Timestamp(end_date))
-        ]
-        if stocks:
-            available = [s for s in stocks if s in df.columns]
-            df = df[available] if available else df
-        df = df.dropna(axis=1)
-        if len(df) < 2:
-            return pd.DataFrame()
-        db_r = df.apply(quotient_diff, axis=0)
-        db_r = db_r[db_r < outlier_return].dropna(axis=0)
-        return db_r
-
     def get_metadata(self, asset: str) -> dict:
         return {**EMPTY_METADATA, "name": asset, "sector": "Unknown"}
 

--- a/tests/test_alpaca_data.py
+++ b/tests/test_alpaca_data.py
@@ -1,0 +1,237 @@
+from tests import import_source_modules
+import_source_modules()
+
+import datetime as dt
+import pytest
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from data.alpaca import AlpacaDataManager
+from data.base import DataManagerBase
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bar_df(tickers, dates) -> pd.DataFrame:
+    """Build a fake Alpaca bars MultiIndex DataFrame."""
+    idx = pd.MultiIndex.from_product(
+        [tickers, pd.DatetimeIndex(dates)],
+        names=["symbol", "timestamp"],
+    )
+    rng = np.random.default_rng(0)
+    prices = 100.0 + rng.normal(0, 2, len(idx)).cumsum()
+    prices = np.abs(prices) + 10   # ensure positive
+    return pd.DataFrame({"close": prices}, index=idx)
+
+
+def _fake_bars(tickers, dates):
+    """Return a mock object whose .df is the bar DataFrame."""
+    mock = MagicMock()
+    mock.df = _make_bar_df(tickers, dates)
+    return mock
+
+
+def _make_dm(tmp_path, tickers, dates, trading_client=None):
+    """Build an AlpacaDataManager backed by a mock data client."""
+    mock_client = MagicMock()
+    mock_client.get_stock_bars.return_value = _fake_bars(tickers, dates)
+    return AlpacaDataManager(
+        cache_dir=tmp_path,
+        _data_client=mock_client,
+        _trading_client=trading_client,
+    )
+
+
+TICKERS = ["AA", "BB", "CC"]
+DATES = pd.bdate_range("2023-01-02", periods=20)
+
+
+# ---------------------------------------------------------------------------
+# DataManagerBase contract
+# ---------------------------------------------------------------------------
+
+def test_alpaca_data_manager_is_data_manager_base():
+    assert issubclass(AlpacaDataManager, DataManagerBase)
+
+
+# ---------------------------------------------------------------------------
+# refresh_cache
+# ---------------------------------------------------------------------------
+
+def test_refresh_cache_creates_parquet_files(tmp_path):
+    dm = _make_dm(tmp_path, TICKERS, DATES)
+    dm.refresh_cache(TICKERS, end_date=DATES[-1].date())
+
+    for ticker in TICKERS:
+        assert (tmp_path / f"{ticker}.parquet").exists()
+
+
+def test_refresh_cache_parquet_has_close_column(tmp_path):
+    dm = _make_dm(tmp_path, TICKERS, DATES)
+    dm.refresh_cache(TICKERS, end_date=DATES[-1].date())
+
+    cached = pd.read_parquet(tmp_path / "AA.parquet")
+    assert "close" in cached.columns
+
+
+def test_refresh_cache_does_not_refetch_up_to_date_tickers(tmp_path):
+    dm = _make_dm(tmp_path, TICKERS, DATES)
+    dm.refresh_cache(TICKERS, end_date=DATES[-1].date())
+
+    call_count_after_first = dm._data_client.get_stock_bars.call_count
+
+    # Second refresh with same end_date — nothing is stale.
+    dm.refresh_cache(TICKERS, end_date=DATES[-1].date())
+    assert dm._data_client.get_stock_bars.call_count == call_count_after_first
+
+
+def test_refresh_cache_incremental_appends_only_new_rows(tmp_path):
+    dates_first = DATES[:10]
+    dates_second = DATES[10:]
+
+    dm = _make_dm(tmp_path, ["AA"], dates_first)
+    dm.refresh_cache(["AA"], end_date=dates_first[-1].date())
+
+    first_len = len(pd.read_parquet(tmp_path / "AA.parquet"))
+
+    # Simulate a second day's worth of data.
+    dm._data_client.get_stock_bars.return_value = _fake_bars(["AA"], dates_second)
+    dm.refresh_cache(["AA"], end_date=dates_second[-1].date())
+
+    total_len = len(pd.read_parquet(tmp_path / "AA.parquet"))
+    assert total_len == first_len + len(dates_second)
+
+
+def test_refresh_cache_atomic_write_leaves_no_tmp_files(tmp_path):
+    dm = _make_dm(tmp_path, ["AA"], DATES)
+    dm.refresh_cache(["AA"], end_date=DATES[-1].date())
+
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert tmp_files == []
+
+
+# ---------------------------------------------------------------------------
+# get_prices
+# ---------------------------------------------------------------------------
+
+def test_get_prices_returns_dataframe_after_refresh(tmp_path):
+    dm = _make_dm(tmp_path, TICKERS, DATES)
+    dm.refresh_cache(TICKERS, end_date=DATES[-1].date())
+
+    prices = dm.get_prices(TICKERS)
+    assert isinstance(prices, pd.DataFrame)
+    assert set(prices.columns) == set(TICKERS)
+
+
+def test_get_prices_date_index_is_datetime(tmp_path):
+    dm = _make_dm(tmp_path, ["AA"], DATES)
+    dm.refresh_cache(["AA"], end_date=DATES[-1].date())
+
+    prices = dm.get_prices(["AA"])
+    assert isinstance(prices.index, pd.DatetimeIndex)
+
+
+def test_get_prices_single_ticker_string(tmp_path):
+    dm = _make_dm(tmp_path, ["AA"], DATES)
+    dm.refresh_cache(["AA"], end_date=DATES[-1].date())
+
+    prices = dm.get_prices("AA")
+    assert "AA" in prices.columns
+
+
+def test_get_prices_empty_when_not_cached(tmp_path):
+    dm = _make_dm(tmp_path, ["AA"], DATES)
+    prices = dm.get_prices(["NOTCACHED"])
+    assert prices.empty
+
+
+# ---------------------------------------------------------------------------
+# get_returns
+# ---------------------------------------------------------------------------
+
+def test_get_returns_shape(tmp_path):
+    dm = _make_dm(tmp_path, TICKERS, DATES)
+    dm.refresh_cache(TICKERS, end_date=DATES[-1].date())
+
+    returns = dm.get_returns(DATES[0], DATES[-1], stocks=TICKERS)
+    # Returns has n-1 rows compared to prices in the window.
+    assert len(returns) > 0
+    assert set(returns.columns) == set(TICKERS)
+
+
+def test_get_returns_values_are_positive(tmp_path):
+    """Gross return ratios must be > 0 for any positive price series."""
+    dm = _make_dm(tmp_path, ["AA"], DATES)
+    dm.refresh_cache(["AA"], end_date=DATES[-1].date())
+
+    returns = dm.get_returns(DATES[0], DATES[-1])
+    assert (returns > 0).all().all()
+
+
+def test_get_returns_empty_for_short_window(tmp_path):
+    dm = _make_dm(tmp_path, ["AA"], DATES)
+    dm.refresh_cache(["AA"], end_date=DATES[-1].date())
+
+    # One-day window → fewer than 2 prices → empty returns.
+    returns = dm.get_returns(DATES[0], DATES[0])
+    assert returns.empty
+
+
+def test_get_returns_outlier_filter_applied(tmp_path):
+    """Returns exceeding outlier_return threshold must be dropped."""
+    dm = _make_dm(tmp_path, ["AA"], DATES)
+    dm.refresh_cache(["AA"], end_date=DATES[-1].date())
+
+    # With threshold = 0.01, almost every return exceeds it → nearly empty.
+    returns = dm.get_returns(DATES[0], DATES[-1], outlier_return=0.01)
+    assert returns.empty or len(returns) < len(DATES) - 1
+
+
+# ---------------------------------------------------------------------------
+# get_metadata
+# ---------------------------------------------------------------------------
+
+def test_get_metadata_returns_dict_with_required_keys(tmp_path):
+    dm = AlpacaDataManager(cache_dir=tmp_path, _data_client=MagicMock(),
+                           _trading_client=None)
+    meta = dm.get_metadata("AAPL")
+    for key in ("name", "sector", "subsector", "market_cap"):
+        assert key in meta
+
+
+def test_get_metadata_uses_trading_client_name(tmp_path):
+    mock_trading = MagicMock()
+    mock_asset = MagicMock()
+    mock_asset.name = "Apple Inc."
+    mock_asset.exchange = "NASDAQ"
+    mock_trading.get_asset.return_value = mock_asset
+
+    dm = AlpacaDataManager(cache_dir=tmp_path, _data_client=MagicMock(),
+                           _trading_client=mock_trading)
+    meta = dm.get_metadata("AAPL")
+    assert meta["name"] == "Apple Inc."
+
+
+def test_get_metadata_cached_after_first_call(tmp_path):
+    mock_trading = MagicMock()
+    mock_trading.get_asset.return_value = MagicMock(name="X", exchange="NYSE")
+
+    dm = AlpacaDataManager(cache_dir=tmp_path, _data_client=MagicMock(),
+                           _trading_client=mock_trading)
+    dm.get_metadata("AAPL")
+    dm.get_metadata("AAPL")
+    assert mock_trading.get_asset.call_count == 1
+
+
+def test_get_metadata_graceful_on_trading_client_failure(tmp_path):
+    mock_trading = MagicMock()
+    mock_trading.get_asset.side_effect = RuntimeError("API down")
+
+    dm = AlpacaDataManager(cache_dir=tmp_path, _data_client=MagicMock(),
+                           _trading_client=mock_trading)
+    meta = dm.get_metadata("AAPL")   # must not raise
+    assert meta["name"] == "AAPL"    # falls back to ticker as name

--- a/tests/test_alpaca_data.py
+++ b/tests/test_alpaca_data.py
@@ -114,9 +114,32 @@ def test_refresh_cache_atomic_write_leaves_no_tmp_files(tmp_path):
     assert tmp_files == []
 
 
+def test_refresh_cache_force_deletes_and_refetches(tmp_path):
+    """force=True must delete the existing cache and re-download from scratch."""
+    dm = _make_dm(tmp_path, ["AA"], DATES[:10])
+    dm.refresh_cache(["AA"], end_date=DATES[9].date())
+
+    first_call_count = dm._data_client.get_stock_bars.call_count
+
+    # Without force, a second refresh for the same end_date is a no-op.
+    dm.refresh_cache(["AA"], end_date=DATES[9].date())
+    assert dm._data_client.get_stock_bars.call_count == first_call_count
+
+    # With force=True the cache file is deleted and re-fetched.
+    dm.refresh_cache(["AA"], end_date=DATES[9].date(), force=True)
+    assert dm._data_client.get_stock_bars.call_count == first_call_count + 1
+
+
 # ---------------------------------------------------------------------------
 # get_prices
 # ---------------------------------------------------------------------------
+
+def test_get_prices_raises_when_cache_empty_and_assets_none(tmp_path):
+    """get_prices(None) must raise if no parquet files exist yet."""
+    dm = _make_dm(tmp_path, ["AA"], DATES)  # no refresh_cache called
+    with pytest.raises(RuntimeError, match="refresh_cache"):
+        dm.get_prices()
+
 
 def test_get_prices_returns_dataframe_after_refresh(tmp_path):
     dm = _make_dm(tmp_path, TICKERS, DATES)

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,420 @@
+from tests import import_source_modules
+import_source_modules()
+
+import datetime as dt
+import math
+import pytest
+import numpy as np
+import pandas as pd
+
+from resources import (
+    Account,
+    Fill,
+    Order,
+    Portfolio,
+    OPERATION_BUY,
+    OPERATION_SELL,
+)
+from backtest import (
+    BacktestConfig,
+    BacktestResult,
+    _cash_at_date,
+    build_benchmark_curve,
+    build_equity_curve,
+    compute_metrics,
+    run_backtest,
+)
+from broker.paper import CostAwarePaperBroker
+from opt_tools import default_cvar_parameters
+from fake import FakeDataManager, make_prices
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+TICKERS = ["AA", "BB", "CC"]
+SPY = "SPY"
+
+_PRICE_DF = make_prices(TICKERS + [SPY], n_days=80)
+
+
+def _fake_dm():
+    return FakeDataManager(_PRICE_DF)
+
+
+def _account_with_one_buy(deposit=10_000.0, qty=50, price=100.0):
+    """Account: deposit on day 0, buy 50 shares of AA on day 1."""
+    d0 = dt.datetime(2023, 1, 2)
+    d1 = dt.datetime(2023, 1, 3)
+    account = Account("test", d0)
+    account.deposit(d0, deposit)
+    account.update_account_from_fills(
+        d1,
+        [Fill("AA", qty, price, OPERATION_BUY, d1, "b-001")],
+    )
+    return account, d0, d1
+
+
+# ---------------------------------------------------------------------------
+# _cash_at_date
+# ---------------------------------------------------------------------------
+
+def test_cash_at_date_after_deposit():
+    account, d0, _ = _account_with_one_buy()
+    assert _cash_at_date(account, d0) == pytest.approx(10_000.0)
+
+
+def test_cash_at_date_after_buy():
+    account, _, d1 = _account_with_one_buy(deposit=10_000.0, qty=50, price=100.0)
+    # 10_000 deposit - 50*100 buy = 5_000
+    assert _cash_at_date(account, d1) == pytest.approx(5_000.0)
+
+
+def test_cash_at_date_after_sell():
+    account, d0, d1 = _account_with_one_buy(deposit=10_000.0, qty=50, price=100.0)
+    d2 = dt.datetime(2023, 1, 4)
+    account.update_account_from_fills(
+        d2,
+        [Fill("AA", 20, 110.0, OPERATION_SELL, d2, "b-002")],
+    )
+    # 5_000 + 20*110 = 7_200
+    assert _cash_at_date(account, d2) == pytest.approx(7_200.0)
+
+
+# ---------------------------------------------------------------------------
+# build_equity_curve
+# ---------------------------------------------------------------------------
+
+def test_equity_curve_includes_cash():
+    """Total value must include uninvested cash, not just equity."""
+    account, d0, d1 = _account_with_one_buy(deposit=10_000.0, qty=50, price=100.0)
+    dm = _fake_dm()
+    curve = build_equity_curve(account, dm)
+
+    # After the buy: equity = 50 * price_of_AA_on_d1, cash = 5_000
+    # Total must be > 5_000 (equity-only would miss the cash)
+    assert not curve.empty
+    first_val = curve.iloc[0]
+    assert first_val > 5_000.0
+
+
+def test_equity_curve_is_series_with_datetime_index():
+    account, _, _ = _account_with_one_buy()
+    curve = build_equity_curve(account, _fake_dm())
+    assert isinstance(curve, pd.Series)
+    assert isinstance(curve.index[0], pd.Timestamp)
+
+
+def test_equity_curve_empty_for_no_trades():
+    """An account with only a deposit and no trades has no equity curve."""
+    d0 = dt.datetime(2023, 1, 2)
+    account = Account("test", d0)
+    account.deposit(d0, 5_000.0)
+    curve = build_equity_curve(account, _fake_dm())
+    assert curve.empty
+
+
+def test_equity_curve_grows_with_price():
+    """When the held stock rises, the equity curve value must rise."""
+    # Build a price DataFrame where AA goes from 100 to 200 over two days
+    dates = pd.bdate_range("2023-01-02", periods=3)
+    prices = pd.DataFrame(
+        {"AA": [100.0, 150.0, 200.0], SPY: [400.0, 410.0, 420.0]},
+        index=dates,
+    )
+    dm = FakeDataManager(prices)
+
+    d0, d1 = dates[0].to_pydatetime(), dates[1].to_pydatetime()
+    account = Account("test", d0)
+    account.deposit(d0, 10_000.0)
+    account.update_account_from_fills(
+        d1, [Fill("AA", 50, 150.0, OPERATION_BUY, d1, "x")]
+    )
+
+    curve = build_equity_curve(account, dm)
+    assert curve.iloc[-1] > curve.iloc[0]
+
+
+def test_equity_curve_accounts_for_two_rebalances():
+    """Curve is continuous across multiple transaction dates."""
+    account, d0, d1 = _account_with_one_buy(deposit=10_000.0, qty=50, price=100.0)
+    d2 = dt.datetime(2023, 1, 5)
+    account.update_account_from_fills(
+        d2,
+        [Fill("BB", 10, 120.0, OPERATION_BUY, d2, "b-003")],
+    )
+    curve = build_equity_curve(account, _fake_dm())
+    assert len(curve) > 1
+
+
+# ---------------------------------------------------------------------------
+# build_benchmark_curve
+# ---------------------------------------------------------------------------
+
+def test_benchmark_curve_mirrors_deposit():
+    """Benchmark buys SPY with the initial deposit; curve reflects SPY price."""
+    d0 = dt.datetime(2023, 1, 2)
+    account = Account("test", d0)
+    account.deposit(d0, 10_000.0)
+
+    dates = pd.bdate_range("2023-01-02", periods=5)
+    spy_start = 400.0
+    prices = pd.DataFrame(
+        {"AA": [100.0] * 5, SPY: [spy_start + i * 4 for i in range(5)]},
+        index=dates,
+    )
+    dm = FakeDataManager(prices)
+    bench = build_benchmark_curve(account, SPY, dm)
+
+    # Expected SPY qty = 10_000 / 400.0 = 25 shares
+    expected_qty = 10_000.0 / spy_start
+    # Benchmark value on last day = 25 * (400 + 4*4) = 25 * 416
+    assert not bench.empty
+    assert bench.iloc[-1] == pytest.approx(expected_qty * prices[SPY].iloc[-1], rel=1e-4)
+
+
+def test_benchmark_curve_two_deposits():
+    """Two deposits each buy more SPY; total qty must be additive."""
+    dates = pd.bdate_range("2023-01-02", periods=10)
+    spy_prices = [400.0 + i for i in range(10)]
+    prices = pd.DataFrame({"SPY": spy_prices}, index=dates)
+    dm = FakeDataManager(prices)
+
+    d0 = dates[0].to_pydatetime()
+    d5 = dates[4].to_pydatetime()
+    account = Account("test", d0)
+    account.deposit(d0, 4_000.0)   # 4000/400 = 10 SPY
+    account.deposit(d5, 2_050.0)   # 2050/404 ≈ 5.07… SPY
+
+    bench = build_benchmark_curve(account, "SPY", dm)
+    # On day 10, total qty ≈ 10 + 2050/404; value ≈ that * price[-1]
+    expected_qty = 4_000.0 / 400.0 + 2_050.0 / float(prices["SPY"].iloc[4])
+    assert bench.iloc[-1] == pytest.approx(expected_qty * float(prices["SPY"].iloc[-1]), rel=1e-3)
+
+
+def test_benchmark_curve_withdrawal_reduces_spy():
+    """A withdrawal sells SPY; benchmark value must be lower than deposit-only."""
+    dates = pd.bdate_range("2023-01-02", periods=6)
+    prices = pd.DataFrame(
+        {"AA": [100.0] * 6, SPY: [400.0] * 6}, index=dates
+    )
+    dm = FakeDataManager(prices)
+
+    d0 = dates[0].to_pydatetime()
+    d3 = dates[2].to_pydatetime()
+    account_full = Account("full", d0)
+    account_full.deposit(d0, 8_000.0)
+
+    account_partial = Account("partial", d0)
+    account_partial.deposit(d0, 8_000.0)
+    account_partial.withdraw(d3, 2_000.0)
+
+    bench_full = build_benchmark_curve(account_full, "SPY", dm)
+    bench_partial = build_benchmark_curve(account_partial, "SPY", dm)
+
+    assert bench_partial.iloc[-1] < bench_full.iloc[-1]
+
+
+def test_benchmark_curve_empty_for_no_cash_flows():
+    d0 = dt.datetime(2023, 1, 2)
+    account = Account("test", d0)
+    bench = build_benchmark_curve(account, SPY, _fake_dm())
+    assert bench.empty
+
+
+# ---------------------------------------------------------------------------
+# compute_metrics
+# ---------------------------------------------------------------------------
+
+def _flat_curve(value=100.0, n=100):
+    dates = pd.bdate_range("2023-01-02", periods=n)
+    return pd.Series([value] * n, index=dates)
+
+
+def _linear_curve(start=100.0, end=120.0, n=252):
+    dates = pd.bdate_range("2023-01-02", periods=n)
+    return pd.Series(np.linspace(start, end, n), index=dates)
+
+
+def test_metrics_total_return():
+    curve = _linear_curve(100.0, 110.0)
+    m = compute_metrics(curve)
+    assert m["total_return"] == pytest.approx(0.10, rel=1e-3)
+
+
+def test_metrics_zero_drawdown_on_monotone_curve():
+    curve = _linear_curve(100.0, 120.0)
+    m = compute_metrics(curve)
+    assert m["max_drawdown"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_metrics_drawdown_detected():
+    dates = pd.bdate_range("2023-01-02", periods=6)
+    # Goes up then drops: 100 → 120 → 80
+    values = [100, 105, 110, 120, 100, 80]
+    curve = pd.Series(values, index=dates, dtype=float)
+    m = compute_metrics(curve)
+    # Max drawdown from 120 to 80 = -40/120 ≈ -0.333
+    assert m["max_drawdown"] == pytest.approx(-40.0 / 120.0, rel=1e-3)
+
+
+def test_metrics_sharpe_positive_for_rising_curve():
+    curve = _linear_curve(100.0, 130.0, n=252)
+    m = compute_metrics(curve)
+    assert m["sharpe"] > 0
+
+
+def test_metrics_information_ratio_present_with_benchmark():
+    portfolio_curve = _linear_curve(100.0, 130.0)
+    benchmark_curve = _linear_curve(100.0, 115.0)
+    m = compute_metrics(portfolio_curve, benchmark_curve)
+    assert "information_ratio" in m
+
+
+def test_metrics_returns_empty_for_short_curve():
+    curve = pd.Series([100.0], index=pd.bdate_range("2023-01-02", periods=1))
+    assert compute_metrics(curve) == {}
+
+
+# ---------------------------------------------------------------------------
+# CostAwarePaperBroker
+# ---------------------------------------------------------------------------
+
+def test_cost_aware_buy_increases_fill_price():
+    broker = CostAwarePaperBroker(cost_bps=10.0)
+    oid = broker.submit_order(Order("AA", 10, 100.0, OPERATION_BUY))
+    fill = broker.get_fill(oid)
+    assert fill.fill_price == pytest.approx(100.0 * (1 + 10 / 10_000))
+
+
+def test_cost_aware_sell_decreases_fill_price():
+    initial = Portfolio.create_from_vectors(["AA"], [20])
+    broker = CostAwarePaperBroker(cost_bps=10.0, initial_portfolio=initial)
+    oid = broker.submit_order(Order("AA", 10, 100.0, OPERATION_SELL))
+    fill = broker.get_fill(oid)
+    assert fill.fill_price == pytest.approx(100.0 * (1 - 10 / 10_000))
+
+
+def test_cost_aware_zero_bps_same_as_paper():
+    broker = CostAwarePaperBroker(cost_bps=0.0)
+    oid = broker.submit_order(Order("AA", 5, 200.0, OPERATION_BUY))
+    fill = broker.get_fill(oid)
+    assert fill.fill_price == pytest.approx(200.0)
+
+
+def test_cost_aware_position_qty_unchanged():
+    """Transaction cost changes price, not quantity."""
+    broker = CostAwarePaperBroker(cost_bps=50.0)
+    broker.submit_order(Order("AA", 10, 100.0, OPERATION_BUY))
+    assert broker.get_positions().get_position("AA") == 10
+
+
+# ---------------------------------------------------------------------------
+# run_backtest (end-to-end on synthetic data)
+# ---------------------------------------------------------------------------
+
+def test_run_backtest_returns_result():
+    prices = make_prices(TICKERS + [SPY], n_days=80)
+    dm = FakeDataManager(prices)
+    schedule = [prices.index[30].to_pydatetime(), prices.index[60].to_pydatetime()]
+    config = BacktestConfig(
+        rebalance_schedule=schedule,
+        lookback_days=25,
+        initial_cash=10_000.0,
+        cvar_params=default_cvar_parameters(),
+        fractional_shares=True,
+    )
+    result = run_backtest(config, dm, benchmark_symbol=SPY)
+    assert isinstance(result, BacktestResult)
+
+
+def test_run_backtest_equity_curve_nonempty():
+    prices = make_prices(TICKERS + [SPY], n_days=80)
+    dm = FakeDataManager(prices)
+    schedule = [prices.index[30].to_pydatetime(), prices.index[60].to_pydatetime()]
+    config = BacktestConfig(
+        rebalance_schedule=schedule,
+        lookback_days=25,
+        initial_cash=10_000.0,
+        cvar_params=default_cvar_parameters(),
+        fractional_shares=True,
+    )
+    result = run_backtest(config, dm, benchmark_symbol=SPY)
+    assert not result.equity_curve.empty
+
+
+def test_run_backtest_benchmark_curve_nonempty():
+    prices = make_prices(TICKERS + [SPY], n_days=80)
+    dm = FakeDataManager(prices)
+    schedule = [prices.index[30].to_pydatetime(), prices.index[60].to_pydatetime()]
+    config = BacktestConfig(
+        rebalance_schedule=schedule,
+        lookback_days=25,
+        initial_cash=10_000.0,
+        cvar_params=default_cvar_parameters(),
+        fractional_shares=True,
+    )
+    result = run_backtest(config, dm, benchmark_symbol=SPY)
+    assert not result.benchmark_curve.empty
+
+
+def test_run_backtest_trades_recorded():
+    prices = make_prices(TICKERS + [SPY], n_days=80)
+    dm = FakeDataManager(prices)
+    schedule = [prices.index[30].to_pydatetime(), prices.index[60].to_pydatetime()]
+    config = BacktestConfig(
+        rebalance_schedule=schedule,
+        lookback_days=25,
+        initial_cash=10_000.0,
+        cvar_params=default_cvar_parameters(),
+        fractional_shares=True,
+    )
+    result = run_backtest(config, dm, benchmark_symbol=SPY)
+    assert not result.trades.empty
+
+
+def test_run_backtest_metrics_populated():
+    prices = make_prices(TICKERS + [SPY], n_days=80)
+    dm = FakeDataManager(prices)
+    schedule = [prices.index[30].to_pydatetime(), prices.index[60].to_pydatetime()]
+    config = BacktestConfig(
+        rebalance_schedule=schedule,
+        lookback_days=25,
+        initial_cash=10_000.0,
+        cvar_params=default_cvar_parameters(),
+        fractional_shares=True,
+    )
+    result = run_backtest(config, dm, benchmark_symbol=SPY)
+    assert "sharpe" in result.metrics
+    assert "max_drawdown" in result.metrics
+    assert "total_return" in result.metrics
+
+
+def test_run_backtest_with_transaction_costs_reduces_cash():
+    """Higher transaction costs should leave less cash after the same trades."""
+    prices = make_prices(TICKERS + [SPY], n_days=80)
+    dm = FakeDataManager(prices)
+    schedule = [prices.index[30].to_pydatetime()]
+
+    config_free = BacktestConfig(
+        rebalance_schedule=schedule,
+        lookback_days=25,
+        initial_cash=10_000.0,
+        transaction_cost_bps=0.0,
+        cvar_params=default_cvar_parameters(),
+        fractional_shares=True,
+    )
+    config_costly = BacktestConfig(
+        rebalance_schedule=schedule,
+        lookback_days=25,
+        initial_cash=10_000.0,
+        transaction_cost_bps=100.0,
+        cvar_params=default_cvar_parameters(),
+        fractional_shares=True,
+    )
+    result_free = run_backtest(config_free, dm, benchmark_symbol=SPY)
+    result_costly = run_backtest(config_costly, dm, benchmark_symbol=SPY)
+
+    # The costly run must have less remaining cash than the free run
+    assert result_costly.account.cash_onhand < result_free.account.cash_onhand

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,188 @@
+from tests import import_source_modules
+import_source_modules()
+
+import datetime as dt
+import pytest
+
+from resources import (
+    Account,
+    Fill,
+    Order,
+    Portfolio,
+    OPERATION_BUY,
+    OPERATION_SELL,
+)
+from broker.paper import PaperBroker
+
+
+# ---------------------------------------------------------------------------
+# PaperBroker — order submission and fills
+# ---------------------------------------------------------------------------
+
+def test_paper_broker_submit_buy_returns_order_id():
+    broker = PaperBroker()
+    order_id = broker.submit_order(Order('AAPL', 10, 150.0, OPERATION_BUY))
+    assert order_id is not None
+    assert len(order_id) > 0
+
+
+def test_paper_broker_fill_matches_order():
+    broker = PaperBroker()
+    order = Order('AAPL', 10, 150.0, OPERATION_BUY)
+    order_id = broker.submit_order(order)
+    fill = broker.get_fill(order_id)
+    assert fill is not None
+    assert fill.ticker == 'AAPL'
+    assert fill.qty == 10
+    assert fill.fill_price == 150.0
+    assert fill.operation_type == OPERATION_BUY
+    assert fill.broker_order_id == order_id
+    assert isinstance(fill.fill_time, dt.datetime)
+
+
+def test_paper_broker_sell_fill():
+    initial = Portfolio.create_from_vectors(['AAPL'], [10])
+    broker = PaperBroker(initial_portfolio=initial)
+    order_id = broker.submit_order(Order('AAPL', 5, 155.0, OPERATION_SELL))
+    fill = broker.get_fill(order_id)
+    assert fill.ticker == 'AAPL'
+    assert fill.qty == 5
+    assert fill.fill_price == 155.0
+    assert fill.operation_type == OPERATION_SELL
+
+
+def test_paper_broker_unknown_order_id_returns_none():
+    broker = PaperBroker()
+    assert broker.get_fill('nonexistent-id') is None
+
+
+# ---------------------------------------------------------------------------
+# PaperBroker — position tracking
+# ---------------------------------------------------------------------------
+
+def test_paper_broker_positions_after_buy():
+    broker = PaperBroker()
+    broker.submit_order(Order('AAPL', 10, 150.0, OPERATION_BUY))
+    broker.submit_order(Order('GOOG', 2, 2800.0, OPERATION_BUY))
+    positions = broker.get_positions()
+    assert positions.get_position('AAPL') == 10
+    assert positions.get_position('GOOG') == 2
+
+
+def test_paper_broker_positions_after_sell():
+    initial = Portfolio.create_from_vectors(['AAPL'], [10])
+    broker = PaperBroker(initial_portfolio=initial)
+    broker.submit_order(Order('AAPL', 10, 155.0, OPERATION_SELL))
+    positions = broker.get_positions()
+    assert positions.get_position('AAPL') == 0
+
+
+def test_paper_broker_positions_accumulate_over_multiple_buys():
+    broker = PaperBroker()
+    broker.submit_order(Order('AAPL', 10, 150.0, OPERATION_BUY))
+    broker.submit_order(Order('AAPL', 5, 152.0, OPERATION_BUY))
+    assert broker.get_positions().get_position('AAPL') == 15
+
+
+def test_paper_broker_oversell_raises():
+    initial = Portfolio.create_from_vectors(['AAPL'], [5])
+    broker = PaperBroker(initial_portfolio=initial)
+    with pytest.raises(ValueError):
+        broker.submit_order(Order('AAPL', 10, 150.0, OPERATION_SELL))
+
+
+# ---------------------------------------------------------------------------
+# PaperBroker — market state and cancel
+# ---------------------------------------------------------------------------
+
+def test_paper_broker_market_open_by_default():
+    broker = PaperBroker()
+    assert broker.is_market_open() is True
+
+
+def test_paper_broker_set_market_open():
+    broker = PaperBroker()
+    broker.set_market_open(False)
+    assert broker.is_market_open() is False
+    broker.set_market_open(True)
+    assert broker.is_market_open() is True
+
+
+def test_paper_broker_cancel_returns_false():
+    # PaperBroker fills immediately, so cancel is always a no-op.
+    broker = PaperBroker()
+    order_id = broker.submit_order(Order('AAPL', 10, 150.0, OPERATION_BUY))
+    assert broker.cancel_order(order_id) is False
+
+
+# ---------------------------------------------------------------------------
+# PaperBroker — submit_and_await_fill (inherited from BrokerBase)
+# ---------------------------------------------------------------------------
+
+def test_submit_and_await_fill_returns_fill():
+    broker = PaperBroker()
+    fill = broker.submit_and_await_fill(
+        Order('MSFT', 5, 300.0, OPERATION_BUY), timeout_seconds=5
+    )
+    assert fill is not None
+    assert fill.ticker == 'MSFT'
+    assert fill.qty == 5
+
+
+# ---------------------------------------------------------------------------
+# Account.update_account_from_fills
+# ---------------------------------------------------------------------------
+
+def test_account_update_from_fills_updates_portfolio():
+    account = Account('holder', dt.datetime(2024, 1, 1))
+    account.deposit(dt.datetime(2024, 1, 1), 10_000.0)
+
+    broker = PaperBroker()
+    order_id = broker.submit_order(Order('AAPL', 10, 150.0, OPERATION_BUY))
+    fill = broker.get_fill(order_id)
+
+    account.update_account_from_fills(dt.datetime(2024, 1, 2), [fill])
+
+    assert account.portfolio.get_position('AAPL') == 10
+    assert account.cash_onhand == pytest.approx(10_000.0 - 10 * 150.0)
+
+
+def test_account_fill_price_differs_from_optimizer_price():
+    """Actual fill price (broker) may differ from optimizer's estimated price."""
+    account = Account('holder', dt.datetime(2024, 1, 1))
+    account.deposit(dt.datetime(2024, 1, 1), 10_000.0)
+
+    fill = Fill(
+        ticker='AAPL',
+        qty=10,
+        fill_price=151.50,       # broker charged 151.50
+        operation_type=OPERATION_BUY,
+        fill_time=dt.datetime(2024, 1, 2, 10, 0),
+        broker_order_id='broker-123',
+    )
+
+    account.update_account_from_fills(dt.datetime(2024, 1, 2), [fill])
+
+    assert account.portfolio.get_position('AAPL') == 10
+    # Cash reflects broker fill price, not a hypothetical optimizer price.
+    assert account.cash_onhand == pytest.approx(10_000.0 - 10 * 151.50)
+
+
+# ---------------------------------------------------------------------------
+# Fill dataclass
+# ---------------------------------------------------------------------------
+
+def test_fill_dataclass_fields():
+    fill = Fill(
+        ticker='TSLA',
+        qty=3.5,
+        fill_price=200.0,
+        operation_type=OPERATION_BUY,
+        fill_time=dt.datetime(2024, 1, 2, 10, 30),
+        broker_order_id='abc-123',
+    )
+    assert fill.ticker == 'TSLA'
+    assert fill.qty == 3.5
+    assert fill.fill_price == 200.0
+    assert fill.operation_type == OPERATION_BUY
+    assert fill.broker_order_id == 'abc-123'

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -236,8 +236,8 @@ def test_account_update_sells_missing_asset():
     assert account.portfolio.get_position('XYZ') == 0
 
 
-def test_account_operations_history():
-    set_account_path(Path(__file__).parent / 'test_data/')
+def test_account_operations_history(tmp_path):
+    set_account_path(tmp_path)
     account = create_new_account('holder_a', dt.datetime(2021, 12, 12))
     account.update_account(dt.datetime(2021, 12, 13, 9, 30),
                            orders=[Order('ABC', 1, 123, OPERATION_BUY)])
@@ -248,28 +248,28 @@ def test_account_operations_history():
                            ])
     account.update_account(dt.datetime(2021, 12, 16, 9, 30),
                            orders=[Order('XYZ', 1, 450, OPERATION_SELL)])
-    
+
     history = account.operations_history()
     assert len(history) == 4
     assert history[0][1] == 123
     assert history[1][1] == 2 * 456
     assert history[2][1] == -0.5 * 123
     assert history[3][1] == -450
-    
+
     account = load_account('holder_a')
     assert account.holder == 'holder_a'
-    
+
     account = load_account('holder_b')
     assert account is None
 
 
-def test_load_account():
-    set_account_path(Path(__file__).parent / 'test_data/')
+def test_load_account(tmp_path):
+    set_account_path(tmp_path)
     create_new_account('holder_a', dt.datetime.now)
-    
+
     account = load_account('holder_a')
     assert account.holder == 'holder_a'
-    
+
     account = load_account('holder_b')
     assert account is None
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -265,13 +265,23 @@ def test_account_operations_history(tmp_path):
 
 def test_load_account(tmp_path):
     set_account_path(tmp_path)
-    create_new_account('holder_a', dt.datetime.now)
+    create_new_account('holder_a', dt.datetime.now())
 
     account = load_account('holder_a')
     assert account.holder == 'holder_a'
 
     account = load_account('holder_b')
     assert account is None
+
+
+def test_create_new_account_default_date_is_datetime(tmp_path):
+    """create_new_account() with no explicit date must store a datetime, not a function."""
+    set_account_path(tmp_path)
+    account = create_new_account('check_date')
+    assert isinstance(account.last_transaction, dt.datetime), (
+        "opening_date default was not evaluated — got "
+        f"{type(account.last_transaction)} instead of datetime"
+    )
 
 
 def test_generate_orders():


### PR DESCRIPTION
## Summary

End-to-end work to make PortfolioManager runnable as a daily scheduled job with real or paper trades. Seven commits in order:

- **Deployment plan** (`DEPLOYMENT_PLAN.md`) — architecture, broker options, scheduling, security, phased rollout
- **Broker integration** — abstract `BrokerBase`, in-memory `PaperBroker` + `CostAwarePaperBroker`, Alpaca adapter (`broker/alpaca.py`); `Fill` dataclass; `Account.update_account_from_fills()`; fix all `DataFrame.append()` → `pd.concat()` (pandas 2.0 crash); fix `get_returns()` cache keyed only on stock list, not date range (stale data in walk-forward loops)
- **Backtesting** (`backtest.py`) — `BacktestConfig`, `BacktestResult`, `build_equity_curve` (includes uninvested cash), `build_benchmark_curve` (mirrors account cash flows, not trades — fixes the benchmark logic), `compute_metrics` (Sharpe, Sortino, max drawdown, Calmar, information ratio), `run_backtest`; 28 hermetic tests via `FakeDataManager`
- **Test data isolation** — `test_account_operations_history` and `test_load_account` used a shared `test_data/` directory, dirtying `index.txt` on every run; switched to `tmp_path`
- **Scheduling + security** — `source/market_hours.py` (NYSE calendar check, `IdempotencyGuard`), `run_daily.py` (main entry point), `deploy/portfolio-manager.service` + `.timer` (systemd), `save_account_atomic()` (write-then-rename), `.env.example`, updated `.gitignore` and `requirements.txt`
- **Bug fixes** in original master code:
  - `create_new_account(opening_date=dt.datetime.now)` — default was the method object, not a datetime; crashes on first `update_account()` call
  - `path_to_file.exists` (no `()`) in `get_sp500_tickers` and `get_tickers_metadata` — guard never fired; `pickle.load` crashed on missing file
  - Same bug mirrored in `test_load_account`; added regression test
- **Data package** (`source/data/`) — `DataManagerBase` ABC formalizing the 3-method interface (`get_prices`, `get_returns`, `get_metadata`); `AlpacaDataManager` backed by a local parquet cache (incremental refresh, atomic writes, no network on hot path); `LocalDataManager` wrapping the original pickle-based workflow; `database_handler.py` reduced to a backward-compat shim; 18 new hermetic tests in `tests/test_alpaca_data.py`; `run_daily.py` updated with `DATA_SOURCE` env var factory selecting `alpaca` vs `local` backend

## Test plan

- [ ] `PYTHONPATH=source python3 -m pytest tests/ -q` — 88 tests, all green
- [ ] `cp .env.example .env` then `python run_daily.py` — exits cleanly on non-trading day, or runs paper simulation if today is a trading day
- [ ] Load a real `.acc` file and run `benchmark2("account_name")` — equity curve vs SPY plotted correctly
- [ ] Run `run_daily.py` twice on the same day — second run exits immediately (idempotency guard)

## Local testing with your .acc file

```bash
# 1. Install deps
pip install -r requirements.txt

# 2. Equity curve vs benchmark from an existing account
#    Replace YOUR_ACCOUNT_NAME with the holder folder name inside accounts/
PYTHONPATH=source python3 - <<'EOF'
from resources import load_account, set_account_path
from backtest import build_equity_curve, build_benchmark_curve, compute_metrics
from database_handler import DataManager
from pathlib import Path

set_account_path(Path("accounts"))           # folder containing your holder dir
account = load_account("YOUR_ACCOUNT_NAME")  # name of the holder subdirectory
dm = DataManager(db_file="data/close.pkl", metadata_file="data/metadata.pkl")

equity  = build_equity_curve(account, dm)
bench   = build_benchmark_curve(account, "SPY", dm)
metrics = compute_metrics(equity, bench)

import matplotlib.pyplot as plt
fig, ax = plt.subplots(figsize=(12, 4))
(equity / equity.iloc[0]).plot(ax=ax, label="Portfolio")
(bench  / bench.iloc[0]).plot(ax=ax, label="SPY")
ax.legend()
ax.set_title("Portfolio vs SPY (normalised)")
plt.savefig("equity_curve.png", dpi=150)
print(metrics)
EOF

# 3. Dry-run daily job (no Alpaca keys needed — falls back to local PaperBroker)
cp .env.example .env
# Edit .env: set ACCOUNT_NAME, ACCOUNT_PATH, DATA_FILE, METADATA_FILE
python run_daily.py

# 4. Test with Alpaca data source (requires Alpaca paper keys)
# Edit .env: DATA_SOURCE=alpaca, ALPACA_API_KEY=..., ALPACA_SECRET_KEY=...
python run_daily.py

# 5. Run tests
PYTHONPATH=source python3 -m pytest tests/ -q
```

https://claude.ai/code/session_01K2ekk8EskamTUoxCUce3xL